### PR TITLE
Refactor SVG scratch buffers to dynamic handles

### DIFF
--- a/Library/Breadbox/Meta/SVG/svg.goc
+++ b/Library/Breadbox/Meta/SVG/svg.goc
@@ -16,6 +16,242 @@
 #include "SVG/svg.h"
 #include "SVG/dbglog.h"
 
+static Boolean SvgScratchEnsureCapacityCommon(SVGScratch *sc, MemHandle *handleP,
+                                             void **ptrP, word *capacityP,
+                                             word neededUnits, word unitSize);
+
+Boolean SvgScratchInit(SVGScratch *sc)
+{
+    word tagSize;
+    word dbSize;
+    word ptsSize;
+    word ptsBytes;
+
+    if (!sc)
+    {
+        return FALSE;
+    }
+
+    sc->tagH = 0;
+    sc->tagP = NULL;
+    sc->tagCapacity = 0;
+    sc->dbH = 0;
+    sc->dbP = NULL;
+    sc->dbCapacity = 0;
+    sc->ptsH = 0;
+    sc->ptsP = NULL;
+    sc->ptsCapacity = 0;
+    sc->allocFailed = FALSE;
+
+    tagSize = TAG_BUF_SIZE;
+    sc->tagH = MemAlloc(tagSize, HF_DYNAMIC, HAF_ZERO_INIT);
+    if (!sc->tagH)
+    {
+        sc->allocFailed = TRUE;
+        SvgScratchFree(sc);
+        return FALSE;
+    }
+    sc->tagP = (char*)MemLock(sc->tagH);
+    if (!sc->tagP)
+    {
+        sc->allocFailed = TRUE;
+        SvgScratchFree(sc);
+        return FALSE;
+    }
+    sc->tagCapacity = tagSize;
+
+    dbSize = MAX_PATH_ATTR_SIZE;
+    sc->dbH = MemAlloc(dbSize, HF_DYNAMIC, HAF_ZERO_INIT);
+    if (!sc->dbH)
+    {
+        sc->allocFailed = TRUE;
+        SvgScratchFree(sc);
+        return FALSE;
+    }
+    sc->dbP = (char*)MemLock(sc->dbH);
+    if (!sc->dbP)
+    {
+        sc->allocFailed = TRUE;
+        SvgScratchFree(sc);
+        return FALSE;
+    }
+    sc->dbCapacity = dbSize;
+
+    ptsSize = MAX_SVG_POINTS;
+    ptsBytes = (word)(ptsSize * sizeof(Point));
+    sc->ptsH = MemAlloc(ptsBytes, HF_DYNAMIC, HAF_ZERO_INIT);
+    if (!sc->ptsH)
+    {
+        sc->allocFailed = TRUE;
+        SvgScratchFree(sc);
+        return FALSE;
+    }
+    sc->ptsP = (Point*)MemLock(sc->ptsH);
+    if (!sc->ptsP)
+    {
+        sc->allocFailed = TRUE;
+        SvgScratchFree(sc);
+        return FALSE;
+    }
+    sc->ptsCapacity = ptsSize;
+
+    return TRUE;
+}
+
+void SvgScratchFree(SVGScratch *sc)
+{
+    if (!sc)
+    {
+        return;
+    }
+
+    if (sc->tagP)
+    {
+        MemUnlock(sc->tagH);
+        sc->tagP = NULL;
+    }
+    if (sc->tagH)
+    {
+        MemFree(sc->tagH);
+        sc->tagH = 0;
+    }
+    sc->tagCapacity = 0;
+
+    if (sc->dbP)
+    {
+        MemUnlock(sc->dbH);
+        sc->dbP = NULL;
+    }
+    if (sc->dbH)
+    {
+        MemFree(sc->dbH);
+        sc->dbH = 0;
+    }
+    sc->dbCapacity = 0;
+
+    if (sc->ptsP)
+    {
+        MemUnlock(sc->ptsH);
+        sc->ptsP = NULL;
+    }
+    if (sc->ptsH)
+    {
+        MemFree(sc->ptsH);
+        sc->ptsH = 0;
+    }
+    sc->ptsCapacity = 0;
+}
+
+Boolean SvgScratchEnsureTagCapacity(SVGScratch *sc, word neededBytes)
+{
+    return SvgScratchEnsureCapacityCommon(sc, &sc->tagH, (void**)&sc->tagP,
+                                          &sc->tagCapacity, neededBytes,
+                                          (word)sizeof(byte));
+}
+
+Boolean SvgScratchEnsurePathBuf(SVGScratch *sc, word neededBytes)
+{
+    return SvgScratchEnsureCapacityCommon(sc, &sc->dbH, (void**)&sc->dbP,
+                                          &sc->dbCapacity, neededBytes,
+                                          (word)sizeof(byte));
+}
+
+Boolean SvgScratchEnsurePointCapacity(SVGScratch *sc, word neededPoints)
+{
+    return SvgScratchEnsureCapacityCommon(sc, &sc->ptsH, (void**)&sc->ptsP,
+                                          &sc->ptsCapacity, neededPoints,
+                                          (word)sizeof(Point));
+}
+
+static Boolean SvgScratchEnsureCapacityCommon(SVGScratch *sc, MemHandle *handleP,
+                                             void **ptrP, word *capacityP,
+                                             word neededUnits, word unitSize)
+{
+    MemHandle newH;
+    void *newP;
+    word current;
+    word newCapacity;
+    Boolean hadPointer;
+    Boolean needInit;
+    word maxUnits;
+
+    if (!sc)
+    {
+        return FALSE;
+    }
+
+    current = *capacityP;
+    if (neededUnits < current)
+    {
+        return TRUE;
+    }
+
+    maxUnits = (word)(0xFFFE / unitSize);
+    newCapacity = current;
+    needInit = (newCapacity == 0);
+    if (needInit)
+    {
+        newCapacity = neededUnits + 1;
+    }
+
+    while (newCapacity <= neededUnits)
+    {
+        if (newCapacity >= maxUnits)
+        {
+            newCapacity = maxUnits;
+            break;
+        }
+        if (newCapacity == 0)
+        {
+            newCapacity = neededUnits + 1;
+            break;
+        }
+        newCapacity = (word)(newCapacity << 1);
+    }
+
+    if (newCapacity <= neededUnits)
+    {
+        sc->allocFailed = TRUE;
+        return FALSE;
+    }
+
+    if (!*handleP)
+    {
+        sc->allocFailed = TRUE;
+        return FALSE;
+    }
+
+    hadPointer = (*ptrP != NULL);
+    if (hadPointer)
+    {
+        MemUnlock(*handleP);
+    }
+
+    newH = MemReAlloc(*handleP, (word)(newCapacity * unitSize), HAF_ZERO_INIT);
+    if (!newH)
+    {
+        if (hadPointer)
+        {
+            *ptrP = (void*)MemLock(*handleP);
+        }
+        sc->allocFailed = TRUE;
+        return FALSE;
+    }
+    *handleP = newH;
+
+    newP = (void*)MemLock(*handleP);
+    if (!newP)
+    {
+        *ptrP = NULL;
+        sc->allocFailed = TRUE;
+        return FALSE;
+    }
+
+    *ptrP = newP;
+    *capacityP = newCapacity;
+    return TRUE;
+}
+
 /*---------------------------------------------------------------
  * ReadSVG -- streamed, SAX-like; callback(last param) is percent
  *---------------------------------------------------------------*/
@@ -61,6 +297,12 @@ TransError _export _pascal ReadSVG(FileHandle srcFile, word settings, ProgressCa
     scP = (SVGScratch*) MemLock(scH);
     if (!scP) { status = TE_OUT_OF_MEMORY; goto cleanup; }
 
+    if (!SvgScratchInit(scP))
+    {
+        status = TE_OUT_OF_MEMORY;
+        goto cleanup;
+    }
+
     ioH = MemAlloc(SVG_IO_BUF_SIZE, HF_DYNAMIC, HAF_ZERO_INIT);
     if (!ioH) { status = TE_OUT_OF_MEMORY; goto cleanup; }
     ioP = (char*) MemLock(ioH);
@@ -74,7 +316,7 @@ TransError _export _pascal ReadSVG(FileHandle srcFile, word settings, ProgressCa
     {
         if (!SvgParserScanNextTag(srcFile, &scan, scP)) { break; }
 
-        LOG_STR_HEAD("[TAG] head", (char*) scP->tag, 96);
+        LOG_STR_HEAD("[TAG] head", scP->tagP, 96);
 
         if (callback && total >= 2048)
         {
@@ -90,13 +332,13 @@ TransError _export _pascal ReadSVG(FileHandle srcFile, word settings, ProgressCa
         }
 
         /* handle comments/declarations, but DO NOT drop close tags blindly */
-        if (scP->tag[0] == '!' || scP->tag[0] == '?')
+        if (scP->tagP[0] == '!' || scP->tagP[0] == '?')
         {
             continue;
         }
 
         /* root close: </svg> */
-        if (scP->tag[0] == '/' && SvgParserTagIs(scP->tag + 1, "svg"))
+        if (scP->tagP[0] == '/' && SvgParserTagIs(scP->tagP + 1, "svg"))
         {
             LOG_STR("[DISPATCH]", "/svg");
             SvgStyleGroupPop();
@@ -104,7 +346,7 @@ TransError _export _pascal ReadSVG(FileHandle srcFile, word settings, ProgressCa
         }
 
         /* group close: </g> */
-        if (scP->tag[0] == '/' && SvgParserTagIs(scP->tag + 1, "g"))
+        if (scP->tagP[0] == '/' && SvgParserTagIs(scP->tagP + 1, "g"))
         {
             LOG_STR("[DISPATCH]", "/g");
             SvgXformGroupPop();
@@ -112,12 +354,12 @@ TransError _export _pascal ReadSVG(FileHandle srcFile, word settings, ProgressCa
             continue;
         }
 
-        if (SvgParserTagIs(scP->tag, "svg"))
+        if (SvgParserTagIs(scP->tagP, "svg"))
         {
             LOG_STR("[SVG]", "root");
             /* inherit root style like a group */
-            SvgStyleGroupPush(scP->tag);
-            SvgViewInitFromSvgTag(scP->tag);
+            SvgStyleGroupPush(scP->tagP);
+            SvgViewInitFromSvgTag(scP->tagP);
             sawSvg = TRUE;
             continue;
         }
@@ -129,52 +371,52 @@ TransError _export _pascal ReadSVG(FileHandle srcFile, word settings, ProgressCa
         }
 
         /* group open: <g ...> — no drawing */
-        if (SvgParserTagIs(scP->tag, "g"))
+        if (SvgParserTagIs(scP->tagP, "g"))
         {
             LOG_STR("[DISPATCH]", "g");
-            SvgStyleGroupPush(scP->tag);
-            SvgXformGroupPush(scP->tag);
+            SvgStyleGroupPush(scP->tagP);
+            SvgXformGroupPush(scP->tagP);
             continue;
         }
 
-        if (SvgParserTagIs(scP->tag, "line"))
+        if (SvgParserTagIs(scP->tagP, "line"))
         {
             LOG_STR("[DISPATCH]", "line");
-            SvgShapeHandleLine(scP->tag);
+            SvgShapeHandleLine(scP->tagP);
         }
-        else if (SvgParserTagIs(scP->tag, "polyline"))
+        else if (SvgParserTagIs(scP->tagP, "polyline"))
         {
             LOG_STR("[DISPATCH]", "polyline");
-            SvgShapeHandlePolyline(scP->tag, scP);
+            SvgShapeHandlePolyline(scP->tagP, scP);
         }
-        else if (SvgParserTagIs(scP->tag, "polygon"))
+        else if (SvgParserTagIs(scP->tagP, "polygon"))
         {
             LOG_STR("[DISPATCH]", "polygon");
-            SvgShapeHandlePolygon(scP->tag, scP);
+            SvgShapeHandlePolygon(scP->tagP, scP);
         }
-        else if (SvgParserTagIs(scP->tag, "rect"))
+        else if (SvgParserTagIs(scP->tagP, "rect"))
         {
             LOG_STR("[DISPATCH]", "rect");
-            SvgShapeHandleRect(scP->tag);
+            SvgShapeHandleRect(scP->tagP);
         }
-        else if (SvgParserTagIs(scP->tag, "ellipse"))
+        else if (SvgParserTagIs(scP->tagP, "ellipse"))
         {
             LOG_STR("[DISPATCH]", "ellipse");
-            SvgShapeHandleEllipse(scP->tag);
+            SvgShapeHandleEllipse(scP->tagP);
         }
-        else if (SvgParserTagIs(scP->tag, "circle"))
+        else if (SvgParserTagIs(scP->tagP, "circle"))
         {
             LOG_STR("[DISPATCH]", "circle");
-            SvgShapeHandleCircle(scP->tag);
+            SvgShapeHandleCircle(scP->tagP);
         }
-        else if (SvgParserTagIs(scP->tag, "path"))
+        else if (SvgParserTagIs(scP->tagP, "path"))
         {
             LOG_STR("[DISPATCH]", "path");
-            SvgPathHandle(scP->tag, scP);
+            SvgPathHandle(scP->tagP, scP);
         }
         else
         {
-            LOG_STR_HEAD("[UNHANDLED_TAG]", scP->tag, 96);
+            LOG_STR_HEAD("[UNHANDLED_TAG]", scP->tagP, 96);
         }
     }
 
@@ -184,9 +426,17 @@ TransError _export _pascal ReadSVG(FileHandle srcFile, word settings, ProgressCa
     }
 
 cleanup:
+    if (scP && scP->allocFailed && status == TE_NO_ERROR)
+    {
+        status = TE_OUT_OF_MEMORY;
+    }
     if (ioP) MemUnlock(ioH);
     if (ioH) MemFree(ioH);
-    if (scP) MemUnlock(scH);
+    if (scP)
+    {
+        SvgScratchFree(scP);
+        MemUnlock(scH);
+    }
     if (scH) MemFree(scH);
     SvgStyleStackFree();
     SvgXformStackFree();

--- a/Library/Breadbox/Meta/SVG/svg.h
+++ b/Library/Breadbox/Meta/SVG/svg.h
@@ -47,18 +47,27 @@ typedef struct {
 
 /* All sizeable scratch buffers kept on heap to keep stack tiny - fixme: put in LMemHeap or something */
 typedef struct _SVGScratch {
-    char    tag[TAG_BUF_SIZE];         // FIXME: make this dynamic!
+    MemHandle   tagH;
+    char       *tagP;
+    word        tagCapacity;
 
-    char    pb[256];
-    char    db[MAX_PATH_ATTR_SIZE];   // FIXME: make this dynamic!
-    char    xb[32], yb[32], x2b[32], y2b[32];
-    char    wb[32], hb[32];
-    char    cxb[32], cyb[32], rxb[32], ryb[32];
-    char    rb[32];
-    char    col[64];
-    char    tbuf[96];
+    MemHandle   dbH;
+    char       *dbP;
+    word        dbCapacity;
 
-    Point   pts[MAX_SVG_POINTS];    // FIXME: make this dynamic!
+    MemHandle   ptsH;
+    Point      *ptsP;
+    word        ptsCapacity;
+
+    Boolean     allocFailed;
+
+    char        pb[256];
+    char        xb[32], yb[32], x2b[32], y2b[32];
+    char        wb[32], hb[32];
+    char        cxb[32], cyb[32], rxb[32], ryb[32];
+    char        rb[32];
+    char        col[64];
+    char        tbuf[96];
 } SVGScratch;
 
 typedef struct {
@@ -83,6 +92,12 @@ Boolean     SvgParserScanNextTag(FileHandle fh, SvgScanCtx *c,
                                  SVGScratch *sc);
 Boolean     SvgParseGetInlineStyleProp(const char *tag, const char *prop,
                                        char *out, word outSize);
+
+Boolean     SvgScratchInit(SVGScratch *sc);
+void        SvgScratchFree(SVGScratch *sc);
+Boolean     SvgScratchEnsureTagCapacity(SVGScratch *sc, word neededBytes);
+Boolean     SvgScratchEnsurePathBuf(SVGScratch *sc, word neededBytes);
+Boolean     SvgScratchEnsurePointCapacity(SVGScratch *sc, word neededPoints);
 
 /* ---- small utility (common) ---- */
 Boolean     SvgUtilAsciiNoCaseEq(const char *a, const char *b);
@@ -156,7 +171,7 @@ void SvgXformGroupPop(void);
 
 /* ---- element-local helpers (legacy scale-only; now superseded by CTM) ---- */
 sword SvgShapeScaleLength(sword v, WWFixedAsDWord s);
-void  SvgShapeParsePoints(const char *points, Point *pointsP, word *numPointsP);
+void  SvgShapeParsePoints(const char *points, SVGScratch *sc, word *numPointsP);
 
 /* ---- tag handlers (dispatch targets) ---- */
 void SvgShapeHandleLine(const char *tag);

--- a/Library/Breadbox/Meta/SVG/svgParse.goc
+++ b/Library/Breadbox/Meta/SVG/svgParse.goc
@@ -190,7 +190,14 @@ Boolean SvgParserScanNextTag(FileHandle fh, SvgScanCtx *c, SVGScratch *sc)
             if (c->inQuote)
             {
                 if (ch == c->quoteCh) c->inQuote = FALSE;
-                if (c->tagLen < (TAG_BUF_SIZE-1)) sc->tag[c->tagLen++] = ch;
+                if (!SvgScratchEnsureTagCapacity(sc, (word)(c->tagLen + 2)))
+                {
+                    c->inTag = FALSE;
+                    c->inQuote = FALSE;
+                    c->tagLen = 0;
+                    return FALSE;
+                }
+                sc->tagP[c->tagLen++] = ch;
                 continue;
             }
             else
@@ -199,16 +206,37 @@ Boolean SvgParserScanNextTag(FileHandle fh, SvgScanCtx *c, SVGScratch *sc)
                 {
                     c->inQuote = TRUE;
                     c->quoteCh = ch;
-                    if (c->tagLen < (TAG_BUF_SIZE-1)) sc->tag[c->tagLen++] = ch;
+                    if (!SvgScratchEnsureTagCapacity(sc, (word)(c->tagLen + 2)))
+                    {
+                        c->inTag = FALSE;
+                        c->inQuote = FALSE;
+                        c->tagLen = 0;
+                        return FALSE;
+                    }
+                    sc->tagP[c->tagLen++] = ch;
                     continue;
                 }
                 if (ch != '>')
                 {
-                    if (c->tagLen < (TAG_BUF_SIZE-1)) sc->tag[c->tagLen++] = ch;
+                    if (!SvgScratchEnsureTagCapacity(sc, (word)(c->tagLen + 2)))
+                    {
+                        c->inTag = FALSE;
+                        c->inQuote = FALSE;
+                        c->tagLen = 0;
+                        return FALSE;
+                    }
+                    sc->tagP[c->tagLen++] = ch;
                     continue;
                 }
 
-                sc->tag[c->tagLen] = 0;
+                if (!SvgScratchEnsureTagCapacity(sc, (word)(c->tagLen + 1)))
+                {
+                    c->inTag = FALSE;
+                    c->inQuote = FALSE;
+                    c->tagLen = 0;
+                    return FALSE;
+                }
+                sc->tagP[c->tagLen] = 0;
                 c->inTag = FALSE;
                 return TRUE;
             }

--- a/Library/Breadbox/Meta/SVG/svgPath.goc
+++ b/Library/Breadbox/Meta/SVG/svgPath.goc
@@ -20,14 +20,14 @@
 /* -------- tiny helpers specific to path handling --------- */
 static void SvgPathAddPt(SVGScratch *sc, word *np, sword x, sword y)
 {
-    if (*np < MAX_SVG_POINTS) {
-        sc->pts[*np].P_x = x;
-        sc->pts[*np].P_y = y;
-        (*np)++;
+    if (!SvgScratchEnsurePointCapacity(sc, (word)(*np + 1)))
+    {
+        LOGF(("[PATH]", "SvgPathAddPt: ensure failed x=%d y=%d", (int)x, (int)y));
+        return;
     }
-    else {
-        LOGF(("[PATH]", "SvgPathAddPt: overflow drop x=%d y=%d", (int)x, (int)y));
-    }
+    sc->ptsP[*np].P_x = x;
+    sc->ptsP[*np].P_y = y;
+    (*np)++;
 }
 
 static Boolean
@@ -148,7 +148,7 @@ SvgPathFlattenArc(SVGScratch *sc, word *pNp,
     Boolean snappedToStart;
 
     sword xi, yi, exi, eyi;
-    word  np, remaining, nSeg, k;
+    word  np, nSeg, k;
 
     LOGF(("[PATH]", "FlattenArc x0=%d y0=%d rx=%d ry=%d rot=%ld laf=%d sf=%d x1=%d y1=%d",
             (int)(x0W>>16), (int)(y0W>>16),
@@ -167,11 +167,15 @@ SvgPathFlattenArc(SVGScratch *sc, word *pNp,
     if ((SvgGeomWWFixedToSWordRound(rxW) == 0) ||
         (SvgGeomWWFixedToSWordRound(ryW) == 0))
     {
-        if (*pNp < MAX_SVG_POINTS)
+        if (SvgScratchEnsurePointCapacity(sc, (word)(*pNp + 1)))
         {
-            sc->pts[*pNp].P_x = SvgGeomWWFixedToSWordRound(x1W);
-            sc->pts[*pNp].P_y = SvgGeomWWFixedToSWordRound(y1W);
+            sc->ptsP[*pNp].P_x = SvgGeomWWFixedToSWordRound(x1W);
+            sc->ptsP[*pNp].P_y = SvgGeomWWFixedToSWordRound(y1W);
             (*pNp)++;
+        }
+        else
+        {
+            LOG_STR("[PATH]", "A: ensure failed for zero radius");
         }
         LOG_STR("[PATH]", "A: zero radius -> straight line");
         return;
@@ -318,13 +322,6 @@ SvgPathFlattenArc(SVGScratch *sc, word *pNp,
 
     /* Emit */
     np        = *pNp;
-    remaining = (MAX_SVG_POINTS > np) ? (MAX_SVG_POINTS - np) : 0;
-    if (remaining == 0)
-    {
-        LOG_STR("[PATH]", "FlattenArc: no buffer space");
-        return;
-    }
-    if (nSeg > remaining) nSeg = remaining;
 
     exi = SvgGeomWWFixedToSWordRound(x1W);
     eyi = SvgGeomWWFixedToSWordRound(y1W);
@@ -356,16 +353,14 @@ SvgPathFlattenArc(SVGScratch *sc, word *pNp,
             snappedToStart = TRUE;
         }
 
-        if (np < MAX_SVG_POINTS)
+        if (!SvgScratchEnsurePointCapacity(sc, (word)(np + 1)))
         {
-            sc->pts[np].P_x = xi;
-            sc->pts[np].P_y = yi;
-            np++;
-        }
-        else
-        {
+            LOG_STR("[PATH]", "FlattenArc: ensure failed");
             break;
         }
+        sc->ptsP[np].P_x = xi;
+        sc->ptsP[np].P_y = yi;
+        np++;
     }
     *pNp = np;
 
@@ -425,11 +420,15 @@ SvgPathHandleMoveTo(const char **sPP, char *lastCmdP,
     *subStartXP = x;
     *subStartYP = y;
 
-    if (*npP < MAX_SVG_POINTS)
+    if (SvgScratchEnsurePointCapacity(sc, (word)(*npP + 1)))
     {
-        sc->pts[*npP].P_x = x;
-        sc->pts[*npP].P_y = y;
+        sc->ptsP[*npP].P_x = x;
+        sc->ptsP[*npP].P_y = y;
         (*npP)++;
+    }
+    else
+    {
+        LOG_STR("[PATH]", "MoveTo: ensure failed");
     }
 
     /* Per SVG spec, any additional coordinate pairs after M/m are L/l */
@@ -487,11 +486,16 @@ SvgPathHandleLineTo(const char **sPP, char lastCmd,
 
         LOGF(("[PATH]", "L to x=%d y=%d", (int)lx, (int)ly));
 
-        if (*npP < MAX_SVG_POINTS)
+        if (SvgScratchEnsurePointCapacity(sc, (word)(*npP + 1)))
         {
-            sc->pts[*npP].P_x = lx;
-            sc->pts[*npP].P_y = ly;
+            sc->ptsP[*npP].P_x = lx;
+            sc->ptsP[*npP].P_y = ly;
             (*npP)++;
+        }
+        else
+        {
+            LOG_STR("[PATH]", "LineTo: ensure failed");
+            break;
         }
 
         *lastxP = lx;
@@ -548,11 +552,16 @@ SvgPathHandleHLineTo(const char **sPP, char lastCmd,
 
         LOGF(("[PATH]", "H to x=%d y=%d", (int)lx, (int)(*lastyP)));
 
-        if (*npP < MAX_SVG_POINTS)
+        if (SvgScratchEnsurePointCapacity(sc, (word)(*npP + 1)))
         {
-            sc->pts[*npP].P_x = lx;
-            sc->pts[*npP].P_y = *lastyP;
+            sc->ptsP[*npP].P_x = lx;
+            sc->ptsP[*npP].P_y = *lastyP;
             (*npP)++;
+        }
+        else
+        {
+            LOG_STR("[PATH]", "HLineTo: ensure failed");
+            break;
         }
 
         *lastxP = lx;
@@ -609,11 +618,16 @@ SvgPathHandleVLineTo(const char **sPP, char lastCmd,
 
         LOGF(("[PATH]", "V to x=%d y=%d", (int)(*lastxP), (int)ly));
 
-        if (*npP < MAX_SVG_POINTS)
+        if (SvgScratchEnsurePointCapacity(sc, (word)(*npP + 1)))
         {
-            sc->pts[*npP].P_x = *lastxP;
-            sc->pts[*npP].P_y = ly;
+            sc->ptsP[*npP].P_x = *lastxP;
+            sc->ptsP[*npP].P_y = ly;
             (*npP)++;
+        }
+        else
+        {
+            LOG_STR("[PATH]", "VLineTo: ensure failed");
+            break;
         }
 
         *lastyP = ly;
@@ -1022,11 +1036,15 @@ SvgPathHandleArc(const char **sPP, char lastCmd,
         if ((SvgGeomWWFixedToSWordRound(rxW) == 0) ||
             (SvgGeomWWFixedToSWordRound(ryW) == 0))
         {
-            if (*npP < MAX_SVG_POINTS)
+            if (SvgScratchEnsurePointCapacity(sc, (word)(*npP + 1)))
             {
-                sc->pts[*npP].P_x = SvgGeomWWFixedToSWordRound(exW);
-                sc->pts[*npP].P_y = SvgGeomWWFixedToSWordRound(eyW);
+                sc->ptsP[*npP].P_x = SvgGeomWWFixedToSWordRound(exW);
+                sc->ptsP[*npP].P_y = SvgGeomWWFixedToSWordRound(eyW);
                 (*npP)++;
+            }
+            else
+            {
+                LOG_STR("[PATH]", "Arc degenerate: ensure failed");
             }
             *lastxP = SvgGeomWWFixedToSWordRound(exW);
             *lastyP = SvgGeomWWFixedToSWordRound(eyW);
@@ -1133,15 +1151,15 @@ SvgPathEmitSubpath(const char *tag, SVGScratch *sc, word *npP, Boolean closed)
 
     w = 0;
     for (i = 0; i < np; i++) {
-        px = sc->pts[i].P_x;
-        py = sc->pts[i].P_y;
+        px = sc->ptsP[i].P_x;
+        py = sc->ptsP[i].P_y;
 
         /* apply full world transform to path vertices */
         SvgXformApplyPoint(&px, &py, &worldM);
 
         if (w == 0 || px != lastx || py != lasty) {
-            sc->pts[w].P_x = px;
-            sc->pts[w].P_y = py;
+            sc->ptsP[w].P_x = px;
+            sc->ptsP[w].P_y = py;
             w++;
             if (w == 1) {
                 firstx = px;
@@ -1159,13 +1177,21 @@ SvgPathEmitSubpath(const char *tag, SVGScratch *sc, word *npP, Boolean closed)
     /* No explicit close for fill while building the compound path. */
     needStrokeClose = (closed && hasStroke &&
                       ((firstx != lastx) || (firsty != lasty)));
-    if (needStrokeClose && (np < MAX_SVG_POINTS)) {
-        sc->pts[np].P_x = firstx;
-        sc->pts[np].P_y = firsty;
-        np++;
+    if (needStrokeClose)
+    {
+        if (SvgScratchEnsurePointCapacity(sc, (word)(np + 1)))
+        {
+            sc->ptsP[np].P_x = firstx;
+            sc->ptsP[np].P_y = firsty;
+            np++;
+        }
+        else
+        {
+            LOG_STR("[PATH]", "EmitSubpath: ensure failed for close");
+        }
     }
 
-    Meta_Polyline(sc->pts, np);
+    Meta_Polyline(sc->ptsP, np);
 }
 
 void SvgPathHandle(const char *tag, SVGScratch *sc)
@@ -1182,16 +1208,22 @@ void SvgPathHandle(const char *tag, SVGScratch *sc)
     Boolean         haveCmd;
     word            emitN;
     char            nextCmd;
+    word            pathBufNeed;
 
     /* snapshot per-<path> style to decide compound path behavior */
     Boolean         pathHasFill, pathHasStroke, buildingCompound;
 
-    sc->db[0] = 0;
-    if (!SvgParserGetAttrBounded(tag, "d", sc->db, sizeof(sc->db))) {
+    pathBufNeed = (word)(strlen(tag) + 1);
+    if (!SvgScratchEnsurePathBuf(sc, pathBufNeed)) {
         return;
     }
 
-    LOG_STR_HEAD("[PATH d]", sc->db, strlen(sc->db));
+    sc->dbP[0] = 0;
+    if (!SvgParserGetAttrBounded(tag, "d", sc->dbP, sc->dbCapacity)) {
+        return;
+    }
+
+    LOG_STR_HEAD("[PATH d]", sc->dbP, strlen(sc->dbP));
 
     /* styles once per <path> */
     SvgStyleApplyStrokeAndFill(tag);
@@ -1226,7 +1258,7 @@ void SvgPathHandle(const char *tag, SVGScratch *sc)
     lastQcx       = 0;
     lastQcy       = 0;
 
-    sP = sc->db;
+    sP = sc->dbP;
 
     while (*sP)
     {

--- a/Library/Breadbox/Meta/SVG/svgShape.goc
+++ b/Library/Breadbox/Meta/SVG/svgShape.goc
@@ -18,7 +18,7 @@
 
 /* ---- points parser (axis-aware) ---- */
 
-void SvgShapeParsePoints(const char *points, Point *pointsP, word *numPointsP)
+void SvgShapeParsePoints(const char *points, SVGScratch *sc, word *numPointsP)
 {
     const char *s;
     sword       x;
@@ -27,7 +27,7 @@ void SvgShapeParsePoints(const char *points, Point *pointsP, word *numPointsP)
     s = points;
     *numPointsP = 0;
 
-    while (*s && *numPointsP < MAX_SVG_POINTS)
+    while (*s)
     {
         s = SvgParserSkipWS(s);
         if (!*s) break;
@@ -65,8 +65,14 @@ void SvgShapeParsePoints(const char *points, Point *pointsP, word *numPointsP)
             s = p;
         }
 
-        pointsP[*numPointsP].P_x = x;
-        pointsP[*numPointsP].P_y = y;
+        if (!SvgScratchEnsurePointCapacity(sc, (word)(*numPointsP + 1)))
+        {
+            LOG_STR("[SHAPE]", "ParsePoints: ensure failed");
+            break;
+        }
+
+        sc->ptsP[*numPointsP].P_x = x;
+        sc->ptsP[*numPointsP].P_y = y;
         (*numPointsP)++;
 
         while (*s && (isspace(*s) || *s == ',')) s++;
@@ -152,21 +158,21 @@ void SvgShapeHandlePolyline(const char *tag, SVGScratch *sc)
         SvgStyleApplyStrokeWidth(tag);
 
         /* parse points in user space */
-        SvgShapeParsePoints(sc->pb, sc->pts, &np);
+        SvgShapeParsePoints(sc->pb, sc, &np);
         if (np > 1)
         {
             /* use full world CTM: View ∘ Group ∘ Element */
             SvgXformBuildWorld(tag, NULL, &worldM);
 
             for (i = 0; i < np; i++) {
-                sword px = sc->pts[i].P_x;
-                sword py = sc->pts[i].P_y;
+                sword px = sc->ptsP[i].P_x;
+                sword py = sc->ptsP[i].P_y;
                 SvgXformApplyPoint(&px, &py, &worldM);
-                sc->pts[i].P_x = px;
-                sc->pts[i].P_y = py;
+                sc->ptsP[i].P_x = px;
+                sc->ptsP[i].P_y = py;
             }
 
-            Meta_Polyline(sc->pts, np);
+            Meta_Polyline(sc->ptsP, np);
         }
     }
 }
@@ -186,21 +192,21 @@ void SvgShapeHandlePolygon(const char *tag, SVGScratch *sc)
         SvgStyleApplyStrokeWidth(tag);
 
         /* parse points in user space */
-        SvgShapeParsePoints(sc->pb, sc->pts, &np);
+        SvgShapeParsePoints(sc->pb, sc, &np);
         if (np > 2)
         {
             /* use full world CTM: View ∘ Group ∘ Element */
             SvgXformBuildWorld(tag, NULL, &worldM);
 
             for (i = 0; i < np; i++) {
-                sword px = sc->pts[i].P_x;
-                sword py = sc->pts[i].P_y;
+                sword px = sc->ptsP[i].P_x;
+                sword py = sc->ptsP[i].P_y;
                 SvgXformApplyPoint(&px, &py, &worldM);
-                sc->pts[i].P_x = px;
-                sc->pts[i].P_y = py;
+                sc->ptsP[i].P_x = px;
+                sc->ptsP[i].P_y = py;
             }
 
-            Meta_Polygon(sc->pts, np, SvgStyleHasFill(tag), SvgStyleHasStroke(tag));
+            Meta_Polygon(sc->ptsP, np, SvgStyleHasFill(tag), SvgStyleHasStroke(tag));
         }
     }
 }


### PR DESCRIPTION
## Summary
- store the SVG scratch tag, path data, and point buffers in dynamically sized handles with init/free/ensure helpers
- initialize and dispose the new buffers in ReadSVG and grow the tag buffer as tags are scanned
- update path and shape handling to operate through the new pointers, expanding buffers when large shapes are parsed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca70d1e5748330bc8a4ffa9ca64d10