### PR TITLE
Handle exponent notation in SVG fixed parser

### DIFF
--- a/Library/Breadbox/Meta/SVG/sample/exponent.svg
+++ b/Library/Breadbox/Meta/SVG/sample/exponent.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="200" height="140" viewBox="0 0 200 140"
+     xmlns="http://www.w3.org/2000/svg">
+
+  <!-- Path data exercising exponent-form numbers -->
+  <path d="M1e1 1.5e1 L6.5e1 2.8e1 9.5e1 7.5e1 z"
+        fill="#88c" stroke="#000" stroke-width="1.5"/>
+
+  <!-- Mixed-sign exponents in transforms and path coordinates -->
+  <g transform="translate(1.2e2,-3.5e1) scale(5e-1,2.5e-1)">
+    <path d="M0 0 L2E2 0 2E2 4.0e1 z"
+          fill="#c88" stroke="#000" stroke-width="2.0E-1"/>
+  </g>
+
+  <!-- Uppercase exponent and explicit plus sign -->
+  <rect x="1.05E2" y="2.2E1" width="3.2e1" height="2.4e1"
+        transform="rotate(4.5e1,1.16e2,3.7e1) translate(1E+1,-2E+0)"
+        fill="#8c8" stroke="#000" stroke-width="1"/>
+</svg>

--- a/Library/Breadbox/Meta/SVG/svgUtil.goc
+++ b/Library/Breadbox/Meta/SVG/svgUtil.goc
@@ -16,6 +16,8 @@
 #include "SVG/svg.h"
 #include "SVG/dbglog.h"
 
+#define SVG_MAX_DECIMAL_EXPONENT 9   /* clamp exponent magnitude to keep WWFixed scaling sane */
+
 /* small ASCII case-insensitive compare */
 Boolean SvgUtilAsciiNoCaseEq(const char *a, const char *b)
 {
@@ -132,11 +134,19 @@ const char* SvgUtilParseWWFixed16_16(const char *s, WWFixedAsDWord *out)
     WWFixedAsDWord   result;
     dword            fpart;
     dword            num;
+    sdword           exponent;
+    sdword           expSign;
+    dword            expValue;
+    Boolean          hasExpDigits;
+    const char      *expStart;
+    WWFixedAsDWord   baseTen;
+    sdword           expLoop;
 
     sign  = 1;
     ip    = 0;
     frac  = 0;
     scale = 1;
+    exponent = 0;
 
     while (*s && isspace((unsigned char)*s))
     {
@@ -181,6 +191,76 @@ const char* SvgUtilParseWWFixed16_16(const char *s, WWFixedAsDWord *out)
         num   = (num + (scale >> 1)) / scale;
         fpart = (num << 8);
         result += (WWFixedAsDWord)fpart;
+    }
+
+    expStart = s;
+    expSign = 1;
+    expValue = 0;
+    hasExpDigits = FALSE;
+    if (*s == 'e' || *s == 'E')
+    {
+        s++;
+        if (*s == '+')
+        {
+            s++;
+        }
+        else if (*s == '-')
+        {
+            expSign = -1;
+            s++;
+        }
+        while ((c = (word)(byte)*s) >= '0' && c <= '9')
+        {
+            hasExpDigits = TRUE;
+            if (expValue < (dword)SVG_MAX_DECIMAL_EXPONENT)
+            {
+                expValue = expValue * 10 + (c - '0');
+                if (expValue > (dword)SVG_MAX_DECIMAL_EXPONENT)
+                {
+                    expValue = (dword)SVG_MAX_DECIMAL_EXPONENT;
+                }
+            }
+            s++;
+        }
+        if (!hasExpDigits)
+        {
+            s = expStart;
+        }
+        else
+        {
+            exponent = (sdword)expValue;
+            if (expSign < 0)
+            {
+                exponent = (sdword)(-exponent);
+            }
+        }
+    }
+
+    if (exponent != 0)
+    {
+        baseTen = SvgGeomMakeWWFixedFromInt(10);
+        if (exponent > 0)
+        {
+            expLoop = exponent;
+            while (expLoop > 0)
+            {
+                result = GrMulWWFixed(result, baseTen);
+                expLoop--;
+            }
+        }
+        else
+        {
+            expLoop = (sdword)(-exponent);
+            while (expLoop > 0)
+            {
+                result = GrSDivWWFixed(result, baseTen);
+                expLoop--;
+                if (result == 0)
+                {
+                    break;
+                }
+            }
+        }
     }
 
     if (sign < 0)


### PR DESCRIPTION
## Summary
- parse optional exponent suffixes in SvgUtilParseWWFixed16_16 and fold them into the 16.16 value
- guard the parser against runaway exponents and reuse WWFixed math for scaling
- add an SVG sample exercising exponent-form numbers in paths and transforms

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca893292f0833091867b6e41a1686c