### PR TITLE
Handle inherited SVG colors and add tests

### DIFF
--- a/Library/Breadbox/Meta/SVG/svg.h
+++ b/Library/Breadbox/Meta/SVG/svg.h
@@ -35,6 +35,8 @@ typedef struct {
     Boolean         frSet;  byte fr;      /* 0=nonzero, 1=evenodd */
     Boolean         lcSet;  byte lc;      /* 0=butt, 1=round, 2=square */
     Boolean         ljSet;  byte lj;      /* 0=miter, 1=round, 2=bevel */
+    Boolean         colorSet;             /* CSS color property (for currentColor) */
+    char            colorVal[64];
 } SvgGroupStyle;
 
 /* ---- shared data types ---- */

--- a/Library/Breadbox/Meta/SVG/svgStyle.goc
+++ b/Library/Breadbox/Meta/SVG/svgStyle.goc
@@ -108,8 +108,15 @@ static Boolean SvgStyleFindNamedColor(const char *name, word *r, word *g, word *
    Supports: "none", "#rgb/#rrggbb", "rgb(...)", named colors,
              "url(#id)" [optional fallback color after ')'].
    Gradients/patterns are not implemented, so any url() without fallback => NONE. */
+static Boolean SvgStyleResolveCurrentColor(const char *tag, word *r, word *g, word *b);
+
 static Boolean
-SvgStyleResolvePaintToSolidOrNone(const char *raw, word *r, word *g, word *b)
+SvgStyleResolvePaintToSolidOrNone(const char *tag,
+                                  const char *prop,
+                                  const char *raw,
+                                  word *r,
+                                  word *g,
+                                  word *b)
 {
     const char *p;
     const char *rp;
@@ -117,9 +124,44 @@ SvgStyleResolvePaintToSolidOrNone(const char *raw, word *r, word *g, word *b)
     word gg;
     word bb;
 
+    Boolean isFill;
+    Boolean isColor;
+
     if (raw == NULL) { return FALSE; }
 
     p = SvgParserSkipWS(raw);
+
+    isFill = (prop != NULL && SvgUtilAsciiNoCaseEq(prop, "fill"));
+    isColor = (prop != NULL && SvgUtilAsciiNoCaseEq(prop, "color"));
+
+    if (SvgUtilAsciiNoCaseEq(p, "inherit"))
+    {
+        char inherited[64];
+        Boolean haveInherited;
+
+        inherited[0] = 0;
+        haveInherited = SvgStyleResolvePropWithGroups(tag, prop,
+                                                     inherited,
+                                                     sizeof(inherited),
+                                                     TRUE);
+        if (!haveInherited || inherited[0] == 0)
+        {
+            if (isFill || isColor)
+            {
+                *r = 0;
+                *g = 0;
+                *b = 0;
+                return TRUE;
+            }
+            return FALSE;
+        }
+        return SvgStyleResolvePaintToSolidOrNone(tag, prop, inherited, r, g, b);
+    }
+
+    if (SvgUtilAsciiNoCaseEq(p, "currentColor"))
+    {
+        return SvgStyleResolveCurrentColor(tag, r, g, b);
+    }
 
     if (SvgUtilAsciiNoCaseEq(p, "none")) {
         return FALSE;
@@ -143,18 +185,14 @@ SvgStyleResolvePaintToSolidOrNone(const char *raw, word *r, word *g, word *b)
                 return FALSE;
             }
 
-            /* Fallback is present: try to parse as color */
-            if (SvgUtilExpandShortHex(after, &rr, &gg, &bb) ||
-                (after[0] == '#' && strlen(after) >= 7 &&
-                 (rr = SvgUtilHexByte(after + 1), gg = SvgUtilHexByte(after + 3), bb = SvgUtilHexByte(after + 5), 1)) ||
-                SvgUtilParseRGBFunc(after, &rr, &gg, &bb) ||
-                SvgStyleFindNamedColor(after, &rr, &gg, &bb))
+            if (SvgStyleResolvePaintToSolidOrNone(tag, prop, after, &rr, &gg, &bb))
             {
-                *r = rr; *g = gg; *b = bb;
+                *r = rr;
+                *g = gg;
+                *b = bb;
                 return TRUE;
             }
 
-            /* Fallback token not a color, treat as NONE */
             return FALSE;
         }
 
@@ -184,6 +222,51 @@ SvgStyleResolvePaintToSolidOrNone(const char *raw, word *r, word *g, word *b)
 
     /* Unknown token -> NONE */
     return FALSE;
+}
+
+static Boolean
+SvgStyleResolveCurrentColor(const char *tag, word *r, word *g, word *b)
+{
+    char colorBuf[64];
+    Boolean haveColor;
+
+    if (r == NULL || g == NULL || b == NULL)
+    {
+        return FALSE;
+    }
+
+    *r = 0;
+    *g = 0;
+    *b = 0;
+
+    if (tag == NULL)
+    {
+        return TRUE;
+    }
+
+    haveColor = SvgStyleResolvePropWithGroups(tag, "color", colorBuf,
+                                              sizeof(colorBuf), FALSE);
+    if (!haveColor || colorBuf[0] == 0)
+    {
+        return TRUE;
+    }
+
+    if (SvgUtilAsciiNoCaseEq(colorBuf, "inherit"))
+    {
+        haveColor = SvgStyleResolvePropWithGroups(tag, "color", colorBuf,
+                                                  sizeof(colorBuf), TRUE);
+        if (!haveColor || colorBuf[0] == 0)
+        {
+            return TRUE;
+        }
+    }
+
+    if (SvgUtilAsciiNoCaseEq(colorBuf, "currentColor"))
+    {
+        return TRUE;
+    }
+
+    return SvgStyleResolvePaintToSolidOrNone(tag, "color", colorBuf, r, g, b);
 }
 
 
@@ -218,6 +301,7 @@ void SvgStyleGroupPush(const char *tag)
     char frBuf[24];
     const char *pwalk;
     SvgGroupStyle *stack;
+    word depth;
 
     stack = SvgStyleStackLock();
     if (stack == NULL) {
@@ -230,6 +314,8 @@ void SvgStyleGroupPush(const char *tag)
     st.fillVal[0] = 0;
     st.strokeVal[0] = 0;
     st.strokeWidth = SvgGeomMakeWWFixedFromInt(1);
+    st.colorSet = FALSE;
+    st.colorVal[0] = 0;
 
     /* inherit from parent */
     st.frSet = FALSE; st.fr = 0;
@@ -248,10 +334,87 @@ void SvgStyleGroupPush(const char *tag)
     if (SvgParseGetInlineStyleProp(tag, "fill", st.fillVal, sizeof(st.fillVal)) ||
         SvgParserGetAttrBounded(tag, "fill", st.fillVal, sizeof(st.fillVal))) {
         st.fillSet = TRUE;
+        if (SvgUtilAsciiNoCaseEq(st.fillVal, "inherit"))
+        {
+            st.fillSet = FALSE;
+            st.fillVal[0] = 0;
+            if (gStyleDepth > 0)
+            {
+                depth = gStyleDepth;
+                while (depth > 0)
+                {
+                    depth--;
+                    if (stack[depth].fillSet)
+                    {
+                        strncpy(st.fillVal, stack[depth].fillVal,
+                                sizeof(st.fillVal) - 1);
+                        st.fillVal[sizeof(st.fillVal) - 1] = 0;
+                        st.fillSet = TRUE;
+                        break;
+                    }
+                }
+            }
+        }
     }
     if (SvgParseGetInlineStyleProp(tag, "stroke", st.strokeVal, sizeof(st.strokeVal)) ||
         SvgParserGetAttrBounded(tag, "stroke", st.strokeVal, sizeof(st.strokeVal))) {
         st.strokeSet = TRUE;
+        if (SvgUtilAsciiNoCaseEq(st.strokeVal, "inherit"))
+        {
+            st.strokeSet = FALSE;
+            st.strokeVal[0] = 0;
+            if (gStyleDepth > 0)
+            {
+                depth = gStyleDepth;
+                while (depth > 0)
+                {
+                    depth--;
+                    if (stack[depth].strokeSet)
+                    {
+                        strncpy(st.strokeVal, stack[depth].strokeVal,
+                                sizeof(st.strokeVal) - 1);
+                        st.strokeVal[sizeof(st.strokeVal) - 1] = 0;
+                        st.strokeSet = TRUE;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    /* color */
+    buf[0] = 0;
+    if (!SvgParseGetInlineStyleProp(tag, "color", buf, sizeof(buf)))
+    {
+        (void)SvgParserGetAttrBounded(tag, "color", buf, sizeof(buf));
+    }
+    if (buf[0])
+    {
+        if (SvgUtilAsciiNoCaseEq(buf, "inherit"))
+        {
+            if (gStyleDepth > 0)
+            {
+                depth = gStyleDepth;
+                while (depth > 0)
+                {
+                    depth--;
+                    if (stack[depth].colorSet)
+                    {
+                        strncpy(st.colorVal, stack[depth].colorVal,
+                                sizeof(st.colorVal) - 1);
+                        st.colorVal[sizeof(st.colorVal) - 1] = 0;
+                        st.colorSet = TRUE;
+                        break;
+                    }
+                }
+            }
+        }
+        else
+        {
+            strncpy(st.colorVal, buf, sizeof(st.colorVal) - 1);
+            st.colorVal[sizeof(st.colorVal) - 1] = 0;
+            st.colorSet = TRUE;
+        }
     }
 
     /* stroke-width */
@@ -326,41 +489,90 @@ void SvgStyleGroupPop(void)
 /* resolve property with group fallback — strings only (fill/stroke) */
 static Boolean SvgStyleResolvePropWithGroups(const char *tag,
                                              const char *prop,
-                                             char *out, word outSize)
+                                             char *out,
+                                             word outSize,
+                                             Boolean skipLocal)
 {
     const SvgGroupStyle *gs;
     SvgGroupStyle *stack;
     Boolean result;
+    Boolean isFill;
+    Boolean isStroke;
+    Boolean isColor;
+    word depth;
 
     if (outSize == 0) return FALSE;
     out[0] = 0;
 
-    if (SvgParseGetInlineStyleProp(tag, prop, out, outSize)) return TRUE;
-    if (SvgParserGetAttrBounded(tag, prop, out, outSize)) return TRUE;
+    if (!skipLocal && tag != NULL)
+    {
+        if (SvgParseGetInlineStyleProp(tag, prop, out, outSize) ||
+            SvgParserGetAttrBounded(tag, prop, out, outSize))
+        {
+            if (!SvgUtilAsciiNoCaseEq(out, "inherit"))
+            {
+                return TRUE;
+            }
+            out[0] = 0;
+        }
+    }
 
     if (gStyleDepth == 0) return FALSE;
     stack = SvgStyleStackLock();
     if (stack == NULL) return FALSE;
 
-    gs = &stack[gStyleDepth-1];
+    isFill = (prop != NULL && SvgUtilAsciiNoCaseEq(prop, "fill"));
+    isStroke = (prop != NULL && SvgUtilAsciiNoCaseEq(prop, "stroke"));
+    isColor = (prop != NULL && SvgUtilAsciiNoCaseEq(prop, "color"));
+
     result = FALSE;
+    depth = gStyleDepth;
 
-    if (!strncmp(prop, "fill", 4) && gs->fillSet)
+    while (depth > 0 && !result)
     {
-        strncpy(out, gs->fillVal, outSize-1);
-        out[outSize-1] = 0;
-        result = TRUE;
-        goto done;
-    }
-    if (!strncmp(prop, "stroke", 6) && gs->strokeSet)
-    {
-        strncpy(out, gs->strokeVal, outSize-1);
-        out[outSize-1] = 0;
-        result = TRUE;
-        goto done;
+        depth--;
+        gs = &stack[depth];
+        if (isFill && gs->fillSet)
+        {
+            strncpy(out, gs->fillVal, outSize - 1);
+            out[outSize - 1] = 0;
+            if (!SvgUtilAsciiNoCaseEq(out, "inherit"))
+            {
+                result = TRUE;
+            }
+            else
+            {
+                out[0] = 0;
+            }
+        }
+        else if (isStroke && gs->strokeSet)
+        {
+            strncpy(out, gs->strokeVal, outSize - 1);
+            out[outSize - 1] = 0;
+            if (!SvgUtilAsciiNoCaseEq(out, "inherit"))
+            {
+                result = TRUE;
+            }
+            else
+            {
+                out[0] = 0;
+            }
+        }
+        else if (isColor && gs->colorSet)
+        {
+            strncpy(out, gs->colorVal, outSize - 1);
+            out[outSize - 1] = 0;
+            if (!SvgUtilAsciiNoCaseEq(out, "inherit"))
+            {
+                result = TRUE;
+            }
+            else
+            {
+                out[0] = 0;
+            }
+        }
     }
 
-done:
     SvgStyleStackUnlock();
     return result;
 }
@@ -380,9 +592,11 @@ void SvgStyleApplyStrokeAndFill(const char *tag)
     sStroke[0] = 0;
 
     /* stroke; initial = none */
-    have = SvgStyleResolvePropWithGroups(tag, "stroke", sStroke, sizeof(sStroke));
+    have = SvgStyleResolvePropWithGroups(tag, "stroke", sStroke,
+                                         sizeof(sStroke), FALSE);
     if (have) {
-        if (SvgStyleResolvePaintToSolidOrNone(sStroke, &r, &g, &b)) {
+        if (SvgStyleResolvePaintToSolidOrNone(tag, "stroke", sStroke,
+                                              &r, &g, &b)) {
             Meta_SetLineColor(CF_RGB, r, g, b);
         }
         /* else NONE: do not set a line color */
@@ -390,12 +604,14 @@ void SvgStyleApplyStrokeAndFill(const char *tag)
     /* else: no property anywhere -> stays NONE */
 
     /* fill; initial = black */
-    have = SvgStyleResolvePropWithGroups(tag, "fill", sFill, sizeof(sFill));
+    have = SvgStyleResolvePropWithGroups(tag, "fill", sFill,
+                                         sizeof(sFill), FALSE);
     if (!have) {
         /* property absent -> initial black */
         Meta_SetAreaColor(CF_RGB, 0, 0, 0);
     } else {
-        if (SvgStyleResolvePaintToSolidOrNone(sFill, &r, &g, &b)) {
+        if (SvgStyleResolvePaintToSolidOrNone(tag, "fill", sFill,
+                                              &r, &g, &b)) {
             Meta_SetAreaColor(CF_RGB, r, g, b);
         }
         /* else NONE: do not set an area color */
@@ -542,8 +758,8 @@ Boolean SvgStyleHasStroke(const char *tag)
     word r;
     word g;
     word bb;
-    if (SvgStyleResolvePropWithGroups(tag, "stroke", b, sizeof(b))) {
-        return SvgStyleResolvePaintToSolidOrNone(b, &r, &g, &bb);
+    if (SvgStyleResolvePropWithGroups(tag, "stroke", b, sizeof(b), FALSE)) {
+        return SvgStyleResolvePaintToSolidOrNone(tag, "stroke", b, &r, &g, &bb);
     }
     return FALSE; /* initial */
 }
@@ -554,8 +770,8 @@ Boolean SvgStyleHasFill(const char *tag)
     word r;
     word g;
     word bb;
-    if (SvgStyleResolvePropWithGroups(tag, "fill", b, sizeof(b))) {
-        return SvgStyleResolvePaintToSolidOrNone(b, &r, &g, &bb);
+    if (SvgStyleResolvePropWithGroups(tag, "fill", b, sizeof(b), FALSE)) {
+        return SvgStyleResolvePaintToSolidOrNone(tag, "fill", b, &r, &g, &bb);
     }
     return TRUE; /* initial */
 }

--- a/Library/Breadbox/Meta/SVG/tests/test_svg_style.py
+++ b/Library/Breadbox/Meta/SVG/tests/test_svg_style.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+
+def write_file(path, content):
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(content)
+
+def process_svg_style(source_path, dest_path):
+    processed_lines = []
+    with open(source_path, "r", encoding="utf-8") as source:
+        for line in source:
+            stripped = line.lstrip()
+            if stripped.startswith("@include"):
+                continue
+            if stripped.startswith("#include"):
+                continue
+            processed_lines.append(line.replace("@SvgNamedColors", "SvgNamedColors"))
+    write_file(dest_path, "".join(processed_lines))
+
+def create_shim_header(path):
+    shim = textwrap.dedent(
+        """
+        #ifndef SVG_STYLE_TEST_SHIM_H
+        #define SVG_STYLE_TEST_SHIM_H
+        #include <stdio.h>
+        #include <stdlib.h>
+        #include <string.h>
+        #include <strings.h>
+        #include <ctype.h>
+        typedef unsigned char byte;
+        typedef unsigned short word;
+        typedef unsigned long dword;
+        typedef long sdword;
+        typedef unsigned long WWFixedAsDWord;
+        typedef int Boolean;
+        typedef void* MemHandle;
+        #define TRUE 1
+        #define FALSE 0
+        #define NullHandle ((MemHandle)0)
+        #define HF_DYNAMIC 0
+        #define HAF_ZERO_INIT 0
+        #define CF_RGB 0
+        #define ODD_EVEN 0
+        #define WINDING 0
+        #define LE_ROUNDCAP 0
+        #define LE_SQUARECAP 0
+        #define LE_BUTTCAP 0
+        #define LJ_ROUND 0
+        #define LJ_BEVELED 0
+        #define LJ_MITERED 0
+        #define SVG_STYLE_GSTACK_MAX 16
+        typedef struct {
+            Boolean fillSet, strokeSet, swSet;
+            char fillVal[64], strokeVal[64];
+            WWFixedAsDWord strokeWidth;
+            Boolean frSet;  byte fr;
+            Boolean lcSet;  byte lc;
+            Boolean ljSet;  byte lj;
+            Boolean colorSet;
+            char colorVal[64];
+        } SvgGroupStyle;
+        typedef struct {
+            byte SNC_r;
+            byte SNC_g;
+            byte SNC_b;
+            char SNC_name[33];
+        } SvgNamedColor;
+        static SvgNamedColor SvgNamedColors[1];
+        static inline MemHandle MemAlloc(word bytes, word flags, word attrs)
+        {
+            (void)flags;
+            (void)attrs;
+            return calloc(1, bytes);
+        }
+        static inline void* MemLock(MemHandle mh)
+        {
+            return mh;
+        }
+        static inline void MemUnlock(MemHandle mh)
+        {
+            (void)mh;
+        }
+        static inline void MemFree(MemHandle mh)
+        {
+            free(mh);
+        }
+        static inline MemHandle OptrToHandle(void *ptr)
+        {
+            (void)ptr;
+            return NullHandle;
+        }
+        static inline void ObjLockObjBlock(MemHandle mh)
+        {
+            (void)mh;
+        }
+        static inline word ChunkArrayGetCount(void *array)
+        {
+            (void)array;
+            return 0;
+        }
+        static inline void* ChunkArrayElementToPtr(void *array, word index, word *elemSize)
+        {
+            (void)array;
+            (void)index;
+            if (elemSize != NULL) {
+                *elemSize = 0;
+            }
+            return NULL;
+        }
+        static inline const char* SvgParserSkipWS(const char *p)
+        {
+            while (p != NULL && *p && isspace((unsigned char)*p)) {
+                p++;
+            }
+            return p;
+        }
+        static inline Boolean SvgUtilAsciiNoCaseEq(const char *a, const char *b)
+        {
+            if (a == NULL || b == NULL) {
+                return FALSE;
+            }
+            while (*a && *b) {
+                if (tolower((unsigned char)*a) != tolower((unsigned char)*b)) {
+                    return FALSE;
+                }
+                a++;
+                b++;
+            }
+            return (*a == 0 && *b == 0);
+        }
+        static inline word SvgUtilHexNibble(char c)
+        {
+            if (c >= '0' && c <= '9') {
+                return (word)(c - '0');
+            }
+            if (c >= 'a' && c <= 'f') {
+                return (word)(c - 'a' + 10);
+            }
+            if (c >= 'A' && c <= 'F') {
+                return (word)(c - 'A' + 10);
+            }
+            return 0;
+        }
+        static inline word SvgUtilHexByte(const char *p)
+        {
+            word hi = SvgUtilHexNibble(p[0]);
+            word lo = SvgUtilHexNibble(p[1]);
+            return (word)((hi << 4) | lo);
+        }
+        static inline Boolean SvgUtilExpandShortHex(const char *s, word *r, word *g, word *b)
+        {
+            if (s == NULL || s[0] != '#' || strlen(s) != 4) {
+                return FALSE;
+            }
+            *r = (word)(SvgUtilHexNibble(s[1]) * 17);
+            *g = (word)(SvgUtilHexNibble(s[2]) * 17);
+            *b = (word)(SvgUtilHexNibble(s[3]) * 17);
+            return TRUE;
+        }
+        static inline Boolean SvgUtilParseRGBFunc(const char *s, word *r, word *g, word *b)
+        {
+            (void)s;
+            (void)r;
+            (void)g;
+            (void)b;
+            return FALSE;
+        }
+        static inline const char* SvgUtilParseWWFixed16_16(const char *s, WWFixedAsDWord *out)
+        {
+            char *endPtr;
+            long value;
+            if (s == NULL || out == NULL) {
+                return s;
+            }
+            value = strtol(s, &endPtr, 10);
+            *out = (WWFixedAsDWord)((unsigned long)(value << 16));
+            return endPtr;
+        }
+        static inline WWFixedAsDWord SvgGeomMakeWWFixedFromInt(int v)
+        {
+            return (WWFixedAsDWord)((unsigned long)(v << 16));
+        }
+        static inline void Meta_SetLineColor(word cf, word r, word g, word b)
+        {
+            (void)cf; (void)r; (void)g; (void)b;
+        }
+        static inline void Meta_SetAreaColor(word cf, word r, word g, word b)
+        {
+            (void)cf; (void)r; (void)g; (void)b;
+        }
+        static inline void Meta_SetFillRule(word rule)
+        {
+            (void)rule;
+        }
+        static inline void Meta_SetLineWidth(WWFixedAsDWord w)
+        {
+            (void)w;
+        }
+        static inline void Meta_SetLineEnd(word end)
+        {
+            (void)end;
+        }
+        static inline void Meta_SetLineJoin(word join)
+        {
+            (void)join;
+        }
+        static inline Boolean SvgParseGetInlineStyleProp(const char *tag, const char *prop,
+                                                         char *out, word outSize)
+        {
+            const char *stylePos;
+            const char *start;
+            const char *end;
+            size_t propLen;
+            if (tag == NULL || prop == NULL || out == NULL || outSize == 0) {
+                return FALSE;
+            }
+            stylePos = strstr(tag, "style=");
+            if (stylePos == NULL) {
+                return FALSE;
+            }
+            start = strchr(stylePos, '\"');
+            if (start == NULL) {
+                return FALSE;
+            }
+            start++;
+            end = strchr(start, '\"');
+            if (end == NULL) {
+                return FALSE;
+            }
+            propLen = strlen(prop);
+            while (start < end) {
+                const char *segmentEnd;
+                while (start < end && isspace((unsigned char)*start)) {
+                    start++;
+                }
+                if ((size_t)(end - start) < propLen) {
+                    break;
+                }
+                if (strncasecmp(start, prop, propLen) == 0 && start[propLen] == ':') {
+                    start += propLen + 1;
+                    while (start < end && isspace((unsigned char)*start)) {
+                        start++;
+                    }
+                    segmentEnd = strchr(start, ';');
+                    if (segmentEnd == NULL || segmentEnd > end) {
+                        segmentEnd = end;
+                    }
+                    while (segmentEnd > start && isspace((unsigned char)segmentEnd[-1])) {
+                        segmentEnd--;
+                    }
+                    if ((word)(segmentEnd - start) >= outSize) {
+                        segmentEnd = start + (outSize - 1);
+                    }
+                    memcpy(out, start, (size_t)(segmentEnd - start));
+                    out[segmentEnd - start] = 0;
+                    return TRUE;
+                }
+                segmentEnd = strchr(start, ';');
+                if (segmentEnd == NULL || segmentEnd >= end) {
+                    break;
+                }
+                start = segmentEnd + 1;
+            }
+            return FALSE;
+        }
+        static inline Boolean SvgParserGetAttrBounded(const char *tag, const char *name,
+                                                      char *out, word outSize)
+        {
+            const char *pos;
+            const char *valueStart;
+            const char *valueEnd;
+            size_t nameLen;
+            if (tag == NULL || name == NULL || out == NULL || outSize == 0) {
+                return FALSE;
+            }
+            nameLen = strlen(name);
+            pos = strstr(tag, name);
+            if (pos == NULL) {
+                return FALSE;
+            }
+            pos += nameLen;
+            while (*pos && isspace((unsigned char)*pos)) {
+                pos++;
+            }
+            if (*pos != '=') {
+                return FALSE;
+            }
+            pos++;
+            while (*pos && isspace((unsigned char)*pos)) {
+                pos++;
+            }
+            if (*pos != '"' && *pos != (char)39) {
+                return FALSE;
+            }
+            valueStart = ++pos;
+            while (*pos && *pos != '"' && *pos != (char)39) {
+                pos++;
+            }
+            if (*pos != '"' && *pos != (char)39) {
+                return FALSE;
+            }
+            valueEnd = pos;
+            if ((size_t)(valueEnd - valueStart) >= outSize) {
+                valueEnd = valueStart + (outSize - 1);
+            }
+            memcpy(out, valueStart, (size_t)(valueEnd - valueStart));
+            out[valueEnd - valueStart] = 0;
+            return TRUE;
+        }
+        #endif
+        """
+    )
+    write_file(path, shim)
+
+def create_test_source(path):
+    test_code = textwrap.dedent(
+        """
+        #include "shim.h"
+        static void SvgStyleStackFree(void);
+        static Boolean SvgStyleResolvePropWithGroups(const char *, const char *, char *, word, Boolean);
+        static Boolean SvgStyleResolvePaintToSolidOrNone(const char *, const char *, const char *, word *, word *, word *);
+        static Boolean SvgStyleResolveCurrentColor(const char *, word *, word *, word *);
+        static void SvgStyleApplyStrokeCapJoin(const char *tag);
+        #include "svgStyle_impl.c"
+        static void assert_true(Boolean cond, const char *message)
+        {
+            if (!cond) {
+                fputs(message, stderr);
+                fputc(10, stderr);
+                exit(1);
+            }
+        }
+        int main(void)
+        {
+            word r;
+            word g;
+            word b;
+            char buf[64];
+            Boolean have;
+            assert_true(SvgStyleStackInit(), "SvgStyleStackInit failed");
+            SvgStyleGroupPush("<g fill='#010203' color='#445566'>");
+            SvgStyleGroupPush("<g fill='inherit' stroke='currentColor'>");
+            have = SvgStyleResolvePropWithGroups("<rect fill='inherit' stroke='currentColor'>",
+                                                 "fill", buf, sizeof(buf), FALSE);
+            assert_true(have, "fill inherit not found");
+            have = SvgStyleResolvePaintToSolidOrNone("<rect fill='inherit' stroke='currentColor'>",
+                                                     "fill", buf, &r, &g, &b);
+            assert_true(have, "fill inherit did not resolve");
+            assert_true(r == 1 && g == 2 && b == 3, "fill inherit wrong value");
+            have = SvgStyleResolvePropWithGroups("<rect fill='inherit' stroke='currentColor'>",
+                                                 "stroke", buf, sizeof(buf), FALSE);
+            assert_true(have, "stroke currentColor not found");
+            have = SvgStyleResolvePaintToSolidOrNone("<rect fill='inherit' stroke='currentColor'>",
+                                                     "stroke", buf, &r, &g, &b);
+            assert_true(have, "stroke currentColor did not resolve");
+            assert_true(r == 0x44 && g == 0x55 && b == 0x66, "stroke currentColor wrong");
+            SvgStyleGroupPop();
+            SvgStyleGroupPop();
+            SvgStyleGroupPush("<g>");
+            have = SvgStyleResolvePropWithGroups("<line stroke='currentColor'>",
+                                                 "stroke", buf, sizeof(buf), FALSE);
+            assert_true(have, "stroke currentColor default not found");
+            have = SvgStyleResolvePaintToSolidOrNone("<line stroke='currentColor'>",
+                                                     "stroke", buf, &r, &g, &b);
+            assert_true(have, "stroke currentColor default did not resolve");
+            assert_true(r == 0 && g == 0 && b == 0, "default currentColor should be black");
+            SvgStyleGroupPop();
+            SvgStyleStackFree();
+            return 0;
+        }
+        """
+    )
+    write_file(path, test_code)
+
+def main():
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", ".."))
+    svg_style_path = os.path.join(repo_root, "Library", "Breadbox", "Meta", "SVG", "svgStyle.goc")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        impl_path = os.path.join(tmpdir, "svgStyle_impl.c")
+        shim_path = os.path.join(tmpdir, "shim.h")
+        test_path = os.path.join(tmpdir, "test.c")
+        binary_path = os.path.join(tmpdir, "svg_style_test")
+        process_svg_style(svg_style_path, impl_path)
+        create_shim_header(shim_path)
+        create_test_source(test_path)
+        compile_cmd = ["gcc", "-std=c99", "-Wall", "-Werror", test_path, "-o", binary_path]
+        env = os.environ.copy()
+        env["C_INCLUDE_PATH"] = tmpdir
+        subprocess.run(compile_cmd, check=True, env=env)
+        subprocess.run([binary_path], check=True, env=env)
+    return 0
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except subprocess.CalledProcessError as err:
+        print(f"Command failed: {err}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- resolve `inherit` and `currentColor` paints by consulting the group stack and the element color property
- store group color state and update property resolution so inherited values propagate through nested groups
- add a python test harness that exercises fill="inherit" and stroke="currentColor" scenarios

## Testing
- python3 Library/Breadbox/Meta/SVG/tests/test_svg_style.py

------
https://chatgpt.com/codex/tasks/task_e_68ca892c4dbc8330a77aa3c1f70455da