### PR TITLE
Add DEL and INS styles to HTML parser

### DIFF
--- a/Library/Breadbox/Html4Par/htmlsty.goh
+++ b/Library/Breadbox/Html4Par/htmlsty.goh
@@ -143,7 +143,10 @@
         TAG_IS_PAR_STYLE,
         },
 
-  /*** DEL: to be implemented ***/
+  {"DEL",      OptrToChunk(@vcdStrike), OptrToChunk(@vpdNone),
+        SPEC_NONE,
+        TAG_IS_CHAR_STYLE,
+        },
 
   {"DFN",       OptrToChunk(@vcdItalic), OptrToChunk(@vpdNone),
     SPEC_NONE,
@@ -256,7 +259,10 @@
     0,
         },
 
-  /*** INS: to be implemented ***/
+  {"INS",      OptrToChunk(@vcdUnderline), OptrToChunk(@vpdNone),
+        SPEC_NONE,
+        TAG_IS_CHAR_STYLE,
+        },
   /*** ISINDEX: to be implemented. ***/
 
   {"KBD",       OptrToChunk(@vcdMono),   OptrToChunk(@vpdNone),


### PR DESCRIPTION
## Summary
- add HTMLStylesTable entries mapping the DEL and INS tags to strike-through and underline character styles
- confirm that CloseTag does not need new SPEC_NONE handling for these inline tags

## Testing
- not run (host environment lacks GEOS runtime for Html4Par validation)


------
https://chatgpt.com/codex/tasks/task_e_68cbd6639bd48330b57d49c94ee3e894