### PR TITLE
Parse inline CSS styles

### DIFF
--- a/Library/Breadbox/Html4Par/htmlpars/htmlpars.goc
+++ b/Library/Breadbox/Html4Par/htmlpars/htmlpars.goc
@@ -400,6 +400,9 @@ void ApplyCharacterDelta(VisTextCharAttr *cs,CharStyleDelta *cd)
       if(cd->CSD_which & CSD_COLOR)
         cs->VTCA_color = cd->CSD_color;
 
+      if(cd->CSD_extendedStyles & VTES_BACKGROUND_COLOR)
+        cs->VTCA_bgColor = cd->CSD_bgColor;
+
       cs->VTCA_textStyles |= cd->CSD_textStyles;
       cs->VTCA_extendedStyles |= cd->CSD_extendedStyles ;
     }

--- a/Library/Breadbox/Html4Par/htmlpars/parstags.goc
+++ b/Library/Breadbox/Html4Par/htmlpars/parstags.goc
@@ -51,7 +51,7 @@ void LOCAL PopStyle(word n) ;
  *              Style constants
  ***************************************************************************/
 
-const CharStyleDelta vcdImage = {CSD_COLOR,0,0,{C_DARK_GRAY,CF_INDEX,0,0},0,0};
+const CharStyleDelta vcdImage = {CSD_COLOR,0,0,{C_DARK_GRAY,CF_INDEX,0,0},{0,0,0,0},0,0};
 
 /* Character used to represent an embedded graphic, in string-ized form... */
 @ifdef DO_DBCS

--- a/Library/Breadbox/Html4Par/htmlpars/stylesh.goc
+++ b/Library/Breadbox/Html4Par/htmlpars/stylesh.goc
@@ -33,7 +33,279 @@
 
 #include "internal.h"
 
+#define CSS_VALUE_BUFFER_SIZE 128
+
+static Boolean CSSMatchKeyword(const char *start, word length, const char *keyword)
+{
+    word i;
+    unsigned char source;
+    unsigned char target;
+
+    for (i = 0; i < length; i++)
+    {
+        if (keyword[i] == 0)
+        {
+            return FALSE;
+        }
+
+        source = (unsigned char)start[i];
+        target = (unsigned char)keyword[i];
+        if (tolower(source) != tolower(target))
+        {
+            return FALSE;
+        }
+    }
+
+    if (keyword[i] != 0)
+    {
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
 void InterpretCSS(char *p, ParaStyleDelta *psd, CharStyleDelta *csd)
 {
-    
+    char *cur;
+    char *propStart;
+    char *propEnd;
+    char *valueStart;
+    char *valueEnd;
+    char *bang;
+    char *found;
+    word propLen;
+    word valueLen;
+    word copyLen;
+    word i;
+    word stringLen;
+    sword numericWeight;
+    ColorQuad color;
+    VisTextParaAttrAttributes attr;
+    char valueBuf[CSS_VALUE_BUFFER_SIZE];
+    char lowerBuf[CSS_VALUE_BUFFER_SIZE];
+
+    if (!p || !psd || !csd)
+    {
+        return;
+    }
+
+    cur = p;
+    while (*cur)
+    {
+        while (*cur && (isspace((unsigned char)*cur) || (*cur == ';')))
+        {
+            cur++;
+        }
+
+        if (!*cur)
+        {
+            break;
+        }
+
+        propStart = cur;
+        while (*cur && (*cur != ':') && (*cur != ';'))
+        {
+            cur++;
+        }
+
+        if (*cur != ':')
+        {
+            while (*cur && (*cur != ';'))
+            {
+                cur++;
+            }
+            if (*cur == ';')
+            {
+                cur++;
+            }
+            continue;
+        }
+
+        propEnd = cur;
+        cur++;
+        valueStart = cur;
+        while (*cur && (*cur != ';'))
+        {
+            cur++;
+        }
+        valueEnd = cur;
+        if (*cur == ';')
+        {
+            cur++;
+        }
+
+        while ((propEnd > propStart) && isspace((unsigned char)*(propEnd - 1)))
+        {
+            propEnd--;
+        }
+        while ((valueStart < valueEnd) && isspace((unsigned char)*valueStart))
+        {
+            valueStart++;
+        }
+        while ((valueEnd > valueStart) && isspace((unsigned char)*(valueEnd - 1)))
+        {
+            valueEnd--;
+        }
+
+        propLen = (word)(propEnd - propStart);
+        valueLen = (word)(valueEnd - valueStart);
+        if ((propLen == 0) || (valueLen == 0))
+        {
+            continue;
+        }
+
+        copyLen = valueLen;
+        if (copyLen >= CSS_VALUE_BUFFER_SIZE)
+        {
+            copyLen = CSS_VALUE_BUFFER_SIZE - 1;
+        }
+        for (i = 0; i < copyLen; i++)
+        {
+            valueBuf[i] = valueStart[i];
+        }
+        valueBuf[copyLen] = 0;
+
+        bang = valueBuf;
+        while (*bang)
+        {
+            if (*bang == '!')
+            {
+                *bang = 0;
+                break;
+            }
+            bang++;
+        }
+
+        stringLen = strlen(valueBuf);
+        while ((stringLen > 0) && isspace((unsigned char)valueBuf[stringLen - 1]))
+        {
+            valueBuf[stringLen - 1] = 0;
+            stringLen--;
+        }
+
+        if ((stringLen >= 2) && ((valueBuf[0] == '"') || (valueBuf[0] == '\'')))
+        {
+            if (valueBuf[stringLen - 1] == valueBuf[0])
+            {
+                for (i = 0; i < stringLen - 1; i++)
+                {
+                    valueBuf[i] = valueBuf[i + 1];
+                }
+                valueBuf[stringLen - 2] = 0;
+                stringLen -= 2;
+            }
+        }
+
+        if (valueBuf[0] == 0)
+        {
+            continue;
+        }
+
+        copyLen = strlen(valueBuf);
+        if (copyLen >= CSS_VALUE_BUFFER_SIZE)
+        {
+            copyLen = CSS_VALUE_BUFFER_SIZE - 1;
+        }
+        for (i = 0; i < copyLen; i++)
+        {
+            lowerBuf[i] = (char)tolower((unsigned char)valueBuf[i]);
+        }
+        lowerBuf[copyLen] = 0;
+
+        if (CSSMatchKeyword(propStart, propLen, "color"))
+        {
+            if ((HTMLext->HE_options & HTML_MONOCHROME) == 0)
+            {
+                if (TranslateColor(valueBuf, &color))
+                {
+                    csd->CSD_color = color;
+                    csd->CSD_which |= CSD_COLOR;
+                }
+            }
+        }
+        else if (CSSMatchKeyword(propStart, propLen, "background-color"))
+        {
+            if (((HTMLext->HE_options & HTML_NO_BACKGROUND) == 0) &&
+                ((HTMLext->HE_options & HTML_MONOCHROME) == 0))
+            {
+                if (strcmp(lowerBuf, "transparent") != 0)
+                {
+                    if (TranslateColor(valueBuf, &color))
+                    {
+                        csd->CSD_bgColor = color;
+                        csd->CSD_extendedStyles |= VTES_BACKGROUND_COLOR;
+                    }
+                }
+            }
+        }
+        else if (CSSMatchKeyword(propStart, propLen, "font-weight"))
+        {
+            if (strstr(lowerBuf, "bold"))
+            {
+                csd->CSD_textStyles |= TS_BOLD;
+            }
+            else if (isdigit((unsigned char)lowerBuf[0]))
+            {
+                numericWeight = ATOISB(lowerBuf);
+                if (numericWeight >= 600)
+                {
+                    csd->CSD_textStyles |= TS_BOLD;
+                }
+            }
+        }
+        else if (CSSMatchKeyword(propStart, propLen, "font-style"))
+        {
+            if (strstr(lowerBuf, "italic") || strstr(lowerBuf, "oblique"))
+            {
+                csd->CSD_textStyles |= TS_ITALIC;
+            }
+        }
+        else if (CSSMatchKeyword(propStart, propLen, "text-decoration"))
+        {
+            if (strcmp(lowerBuf, "none") == 0)
+            {
+                continue;
+            }
+
+            found = strstr(lowerBuf, "underline");
+            if (found)
+            {
+                csd->CSD_textStyles |= TS_UNDERLINE;
+            }
+
+            if (strstr(lowerBuf, "line-through") || strstr(lowerBuf, "line through") ||
+                strstr(lowerBuf, "strikethrough"))
+            {
+                csd->CSD_textStyles |= TS_STRIKE_THRU;
+            }
+        }
+        else if (CSSMatchKeyword(propStart, propLen, "text-align"))
+        {
+            attr = psd->PSD_attributes;
+            attr &= ~VTPAA_JUSTIFICATION;
+            if ((strcmp(lowerBuf, "center") == 0) || (strcmp(lowerBuf, "middle") == 0))
+            {
+                attr |= (J_CENTER << VTPAA_JUSTIFICATION_OFFSET);
+            }
+            else if (strcmp(lowerBuf, "right") == 0)
+            {
+                attr |= (J_RIGHT << VTPAA_JUSTIFICATION_OFFSET);
+            }
+            else if (strcmp(lowerBuf, "justify") == 0)
+            {
+                attr |= (J_FULL << VTPAA_JUSTIFICATION_OFFSET);
+            }
+            else if ((strcmp(lowerBuf, "left") == 0) || (strcmp(lowerBuf, "start") == 0))
+            {
+                attr |= (J_LEFT << VTPAA_JUSTIFICATION_OFFSET);
+            }
+            else
+            {
+                continue;
+            }
+
+            psd->PSD_attributes = attr;
+            psd->PSD_which |= PSD_JUSTIFY;
+        }
+    }
 }

--- a/Library/Breadbox/Html4Par/htmlpars/tests/inline-css-regression.html
+++ b/Library/Breadbox/Html4Par/htmlpars/tests/inline-css-regression.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Inline CSS Regression</title>
+    <style>
+        body {
+            font-family: serif;
+        }
+        .sample-block {
+            border: 1px dashed #888;
+            margin: 8px 0;
+            padding: 4px;
+        }
+        .note {
+            font-size: 80%;
+            color: #333;
+        }
+    </style>
+</head>
+<body>
+    <h1>Inline CSS Regression Samples</h1>
+    <p class="note">These samples exercise inline style parsing for color, background-color, font-weight, font-style, text-decoration, and text-align.</p>
+
+    <div class="sample-block" style="color: #0033cc; font-weight: bold; text-align: center;">
+        Centered bold blue text via inline CSS.
+    </div>
+
+    <div class="sample-block" style="background-color: rgb(240, 248, 255); color: #000; text-align: left;">
+        <span style="font-style: italic;">Left aligned italic text with light background.</span>
+    </div>
+
+    <div class="sample-block" style="background-color: #222; color: white; font-weight: 700; text-decoration: underline line-through; text-align: right;">
+        Right aligned white text with underline and strike-through on dark background.
+    </div>
+
+    <p class="note">Inspect each block to confirm that inline styles are reflected in the rendered output.</p>
+</body>
+</html>

--- a/Library/Breadbox/Html4Par/htmlsty.goh
+++ b/Library/Breadbox/Html4Par/htmlsty.goh
@@ -12,24 +12,24 @@
 
 @start StyleResource, data;
 
-@chunk CharStyleDelta vcdNone =        {0,0,0,{0,0,0,0},0,0};
-@chunk CharStyleDelta vcdReset =       {CSD_RESET,0,0,{0,0,0,0},0,0};
-@chunk CharStyleDelta vcdH1 =          {CSD_SIZE,0,7,{0,0,0,0},TS_BOLD,0};
-@chunk CharStyleDelta vcdH2 =          {CSD_SIZE,0,6,{0,0,0,0},TS_BOLD,0};
-@chunk CharStyleDelta vcdH3 =          {CSD_SIZE,0,5,{0,0,0,0},TS_BOLD,0};
-@chunk CharStyleDelta vcdH4 =          {CSD_SIZE,0,4,{0,0,0,0},TS_BOLD,0};
-@chunk CharStyleDelta vcdH5 =          {CSD_SIZE,0,3,{0,0,0,0},TS_BOLD,0};
-@chunk CharStyleDelta vcdH6 =          {CSD_SIZE,0,2,{0,0,0,0},TS_BOLD,0};
-@chunk CharStyleDelta vcdBold =        {0,0,0,{0,0,0,0},TS_BOLD,0};
-@chunk CharStyleDelta vcdItalic =      {0,0,0,{0,0,0,0},TS_ITALIC,0};
-@chunk CharStyleDelta vcdUnderline =   {0,0,0,{0,0,0,0},TS_UNDERLINE,0};
-@chunk CharStyleDelta vcdStrike =      {0,0,0,{0,0,0,0},TS_STRIKE_THRU,0};
-@chunk CharStyleDelta vcdSuperscript = {0,0,0,{0,0,0,0},TS_SUPERSCRIPT,0};
-@chunk CharStyleDelta vcdSubscript =   {0,0,0,{0,0,0,0},TS_SUBSCRIPT,0};
-@chunk CharStyleDelta vcdBig =         {CSD_SIZE,0,4,{0,0,0,0},0,0};
-@chunk CharStyleDelta vcdSmall =       {CSD_SIZE,0,2,{0,0,0,0},0,0};
-@chunk CharStyleDelta vcdMono =  {CSD_BASE,CSD_BASE_EXAMPLE,0,{0,0,0,0},0,0};
-@chunk CharStyleDelta vcdNOBR =  {CSD_EXTENDED,0,0,{0,0,0,0},0,VTES_NOWRAP};
+@chunk CharStyleDelta vcdNone =        {0,0,0,{0,0,0,0},{0,0,0,0},0,0};
+@chunk CharStyleDelta vcdReset =       {CSD_RESET,0,0,{0,0,0,0},{0,0,0,0},0,0};
+@chunk CharStyleDelta vcdH1 =          {CSD_SIZE,0,7,{0,0,0,0},{0,0,0,0},TS_BOLD,0};
+@chunk CharStyleDelta vcdH2 =          {CSD_SIZE,0,6,{0,0,0,0},{0,0,0,0},TS_BOLD,0};
+@chunk CharStyleDelta vcdH3 =          {CSD_SIZE,0,5,{0,0,0,0},{0,0,0,0},TS_BOLD,0};
+@chunk CharStyleDelta vcdH4 =          {CSD_SIZE,0,4,{0,0,0,0},{0,0,0,0},TS_BOLD,0};
+@chunk CharStyleDelta vcdH5 =          {CSD_SIZE,0,3,{0,0,0,0},{0,0,0,0},TS_BOLD,0};
+@chunk CharStyleDelta vcdH6 =          {CSD_SIZE,0,2,{0,0,0,0},{0,0,0,0},TS_BOLD,0};
+@chunk CharStyleDelta vcdBold =        {0,0,0,{0,0,0,0},{0,0,0,0},TS_BOLD,0};
+@chunk CharStyleDelta vcdItalic =      {0,0,0,{0,0,0,0},{0,0,0,0},TS_ITALIC,0};
+@chunk CharStyleDelta vcdUnderline =   {0,0,0,{0,0,0,0},{0,0,0,0},TS_UNDERLINE,0};
+@chunk CharStyleDelta vcdStrike =      {0,0,0,{0,0,0,0},{0,0,0,0},TS_STRIKE_THRU,0};
+@chunk CharStyleDelta vcdSuperscript = {0,0,0,{0,0,0,0},{0,0,0,0},TS_SUPERSCRIPT,0};
+@chunk CharStyleDelta vcdSubscript =   {0,0,0,{0,0,0,0},{0,0,0,0},TS_SUBSCRIPT,0};
+@chunk CharStyleDelta vcdBig =         {CSD_SIZE,0,4,{0,0,0,0},{0,0,0,0},0,0};
+@chunk CharStyleDelta vcdSmall =       {CSD_SIZE,0,2,{0,0,0,0},{0,0,0,0},0,0};
+@chunk CharStyleDelta vcdMono =  {CSD_BASE,CSD_BASE_EXAMPLE,0,{0,0,0,0},{0,0,0,0},0,0};
+@chunk CharStyleDelta vcdNOBR =  {CSD_EXTENDED,0,0,{0,0,0,0},{0,0,0,0},0,VTES_NOWRAP};
 
 /******************************************************************************/
 

--- a/Library/Breadbox/Html4Par/internal.h
+++ b/Library/Breadbox/Html4Par/internal.h
@@ -119,6 +119,7 @@ typedef struct
   } CSD_fontOrBase;
   sword       CSD_pointSize;            /* point size (1..7) */
   ColorQuad CSD_color;
+  ColorQuad CSD_bgColor;
   TextStyle CSD_textStyles;             /* style flags - added to current */
   VisTextExtendedStyles CSD_extendedStyles ;
 } CharStyleDelta;


### PR DESCRIPTION
## Summary
- parse inline style attributes and map color, background color, weight, emphasis, decoration, and alignment into the existing style deltas
- extend `CharStyleDelta` handling so inline background colors are preserved and applied during rendering
- add an inline CSS regression HTML sample covering the supported properties

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cbd99ba4988330b633e4e5e60cd443