### PR TITLE
Handle UTF-8 form encoding flag

### DIFF
--- a/Appl/Breadbox/BbxBrow/htmlview/UIRare.goc
+++ b/Appl/Breadbox/BbxBrow/htmlview/UIRare.goc
@@ -153,9 +153,8 @@ void UpdateTitleAndURL(NameToken title, NameToken url)
 @ifdef DO_DBCS
     /* DBCS TBD: get code page from menu? */
     ext->HE_codePage = G_codePage;
-@else
-    ext->HE_decodeUtf8 = FALSE;
 @endif
+    ext->HE_decodeUtf8 = FALSE;
 }
 
 @extern method HTMLVProcessClass, MSG_HMLVP_LOAD_GRAPHICS_CHANGED

--- a/Appl/Breadbox/BbxBrow/urltext/URLTEXT.goc
+++ b/Appl/Breadbox/BbxBrow/urltext/URLTEXT.goc
@@ -57,6 +57,7 @@
 /* abort handling */
 extern Boolean UserAbortCheck(void);
 extern void UserAbortEnd(void);
+extern Boolean G_decodeUtf8;
 
 /***************************************************************************
  *              URL-aware HTML page class
@@ -1827,6 +1828,7 @@ void ShowJSAnalysis(URLTextInstance *pself, VMFileHandle vmf, VMChain vmc)
     /* set code page */
     pself->HTI_codePage = G_codePage;
 #endif
+    pself->HTI_decodeUtf8 = G_decodeUtf8;
 
     /* Reset the status bar for javascript messages */
     @SendStatusUpdateOptr(

--- a/CInclude/html4par.goh
+++ b/CInclude/html4par.goh
@@ -729,9 +729,8 @@ typedef struct {
 
 @ifdef DO_DBCS
   DosCodePage    HE_codePage;
-@else
-  Boolean        HE_decodeUtf8;
 @endif
+  Boolean        HE_decodeUtf8;
 } HTMLextra;
 
 @ifdef JAVASCRIPT_SUPPORT
@@ -1178,4 +1177,5 @@ typedef dword T_tableArrayHandle ;
 @ifdef DO_DBCS
   @instance DosCodePage HTI_codePage = 0;
 @endif
+  @instance Boolean HTI_decodeUtf8 = FALSE;
 @endc;

--- a/Library/Breadbox/Html4Par/htmlclas/htmlform.goc
+++ b/Library/Breadbox/Html4Par/htmlclas/htmlform.goc
@@ -40,6 +40,7 @@
 
 #define INITIAL_TEXTAREA_BLOCK_SIZE    300
 
+extern Boolean G_decodeUtf8;
 @ifdef DO_DBCS
 extern DosCodePage G_htmlCodePage;
 @endif
@@ -649,10 +650,11 @@ static dword FormStringLengthMulti(T_formString *postData);
     word imageSubmit = 0xffff;  /* nothing yet */
     word argsOffset = 0xffff;
 
-@ifdef DO_DBCS
+    G_decodeUtf8 = pself->HTI_decodeUtf8;
+#ifdef DO_DBCS
     /* set code page for form submit */
     G_htmlCodePage = pself->HTI_codePage;
-@endif
+#endif
 
     array = pself->HTI_formArray ;
     if (array)  {

--- a/Library/Breadbox/Html4Par/htmlpars/htmlpars.goc
+++ b/Library/Breadbox/Html4Par/htmlpars/htmlpars.goc
@@ -131,9 +131,8 @@ static word scriptCount;
    (used in ApplyFontWeightWidthAndSpacingAdjustment, set in ParseHTMLFile,
    ParsePlainFile, and MSG_VIS_TEXT_GRAPHIC_VARIABLE_DRAW) */
 DosCodePage G_htmlCodePage;
-#else
-Boolean G_decodeUtf8;
 #endif
+Boolean G_decodeUtf8;
 
 /***************************************************************************
  *              Translate between style sheet and Geos attributes
@@ -687,6 +686,7 @@ void CleanupJavaScript(long pos1, long pos2)
 
 void SetDocumentCharset(char *p)
 {
+    Boolean isUtf8;
 @ifdef DO_DBCS
     int i, j;
     char buf[15];
@@ -696,38 +696,39 @@ void SetDocumentCharset(char *p)
     DosCodePage cp;
     word size;
     Boolean found = FALSE;
+@endif
 
+    isUtf8 = (!STRCMPISB(p, "UTF-8")) ? TRUE : FALSE;
+    HTMLext->HE_decodeUtf8 = isUtf8;
+    G_decodeUtf8 = isUtf8;
+
+@ifdef DO_DBCS
     /* this should only happen once per page, so we'll just read
     the .ini file directly (instead of buffering .ini data) */
     for (i = 0; i < NUM_CODE_PAGE_FONT_ADJ_ENTRIES; i++) {
       sprintfsbcs(buf, "cp-%d", i);
       if (!InitFileReadInteger("HTMLView", buf, (word*)&cp)) {
-	sprintfsbcs(buf, "cp%uid", cp);
-	j = 0;
-	while (!InitFileReadStringSectionBuffer("HTMLView", buf,
-						j++, (char*)id,
-						sizeof(id)/sizeof(TCHAR),
-						&size)) {
-	  /* convert ASCII-only id string to single-byte */
-	  idTP = id; idCP = (char *)id;
-	  while(*idTP) *idCP++ = *idTP++; *idCP = 0;
-	  if (!strncmpisb(p, (char*)id, 0)) {
-	    /* set new code page */
-	    HTMLext->HE_codePage = cp;
-	    G_htmlCodePage = cp;
-	    /* update base font */
-	    ApplyFontWeightWidthAndSpacingAdjustment(&vcaBase, TRUE);
-	    found = TRUE;
-	    break;
-	  }
-	}
+        sprintfsbcs(buf, "cp%uid", cp);
+        j = 0;
+        while (!InitFileReadStringSectionBuffer("HTMLView", buf,
+                                                j++, (char*)id,
+                                                sizeof(id)/sizeof(TCHAR),
+                                                &size)) {
+          /* convert ASCII-only id string to single-byte */
+          idTP = id; idCP = (char *)id;
+          while(*idTP) *idCP++ = *idTP++; *idCP = 0;
+          if (!strncmpisb(p, (char*)id, 0)) {
+            /* set new code page */
+            HTMLext->HE_codePage = cp;
+            G_htmlCodePage = cp;
+            /* update base font */
+            ApplyFontWeightWidthAndSpacingAdjustment(&vcaBase, TRUE);
+            found = TRUE;
+            break;
+          }
+        }
       }
       if (found) break;
-    }
-@else
-    if (!strcmp(p, "UTF-8")) {
-      HTMLext->HE_decodeUtf8 = TRUE;
-      G_decodeUtf8 = TRUE;
     }
 @endif
 }
@@ -2212,9 +2213,8 @@ int EXPORT ParseHTMLFile(ReadHTML_getc *p_gc, dword p_data, HTMLextra *ext,
     HTMLext = ext;                      /* Make extra data available globally */
 #ifdef DO_DBCS
     G_htmlCodePage = HTMLext->HE_codePage;
-#else
-    G_decodeUtf8 = HTMLext->HE_decodeUtf8;
 #endif
+    G_decodeUtf8 = HTMLext->HE_decodeUtf8;
     *item = InitTransferItem();         /* initialize & return transfer item */
     InitTagStacks(localHeap);           /* set up tag stacks */
 
@@ -2427,9 +2427,8 @@ int EXPORT ParsePlainFile(ReadHTML_getc *p_gc, dword p_data, HTMLextra *ext,
     HTMLext = ext;                      /* Make extra data available globally */
 #ifdef DO_DBCS
     G_htmlCodePage = HTMLext->HE_codePage;
-#else
-    G_decodeUtf8 = HTMLext->HE_decodeUtf8;
 #endif
+    G_decodeUtf8 = HTMLext->HE_decodeUtf8;
     *item = InitTransferItem();         /* initialize & return transfer item */
     InitTagStacks(localHeap);           /* set up tag stacks */
 


### PR DESCRIPTION
## Summary
- normalize charset comparison in SetDocumentCharset and track UTF-8 decoding for all builds
- add an HTMLText instance flag for UTF-8 decoding and populate it from HTMLextra during attachment
- expose the UTF-8 flag to form submission so downstream helpers can choose the proper encoding

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc073ddafc8330a0040890e58f3ce1