### PR TITLE
Handle VCImpex import defaults when UI is absent

### DIFF
--- a/Library/Breadbox/Impex/VCImpex/VCImpex/vcimpexManager.asm
+++ b/Library/Breadbox/Impex/VCImpex/VCImpex/vcimpexManager.asm
@@ -121,19 +121,25 @@ TransGetImportOptions proc far
         push    di
         push    ds
 
+        cmp     dx,0
+        jne     iopt_query_ui
+        mov     ax,8001h                 ; SETTINGS_DOARCS | SETTINGS_DOTEXT defaults
+        jmp     short iopt_have_options
+iopt_query_ui:
         mov     ax,MSG_GEN_BOOLEAN_GROUP_GET_SELECTED_BOOLEANS
         mov     bx,dx
         mov     si,offset _booleanOptions
         mov     di,mask MF_CALL
         call    ObjMessage
 
+iopt_have_options:
         push    ax
         mov     ax,00002h
         mov     cl,050h
         mov     ch,040h
         call    MemAlloc
         xor     dx,dx
-        jc      iopt_err
+        jc      iopt_discard_saved
         push    ax
         pop     ds
         pop     ax
@@ -141,7 +147,10 @@ TransGetImportOptions proc far
         call    MemUnlock
         mov     dx,bx
         clc
-iopt_err:
+        jmp     short iopt_exit
+iopt_discard_saved:
+        pop     ax
+iopt_exit:
         pop     ds
         pop     di
         pop     si

--- a/Library/Breadbox/Impex/VCImpex/imptproc/imptproc.goc
+++ b/Library/Breadbox/Impex/VCImpex/imptproc/imptproc.goc
@@ -112,30 +112,49 @@ dword _export _pascal ImportProcedure(ImportFrame *ieb,VMChain *vmc)
     struct ie_uidata *uidata;
     VMBlockHandle gsblock;
     GStateHandle tempGS;
+    struct ie_uidata defaultUidata;
+    word resolvedOptions;
+    Boolean optionsLocked;
 
     ImpexUpdateImportExportStatus("File is being converted",-1);
 
-    uidata = (struct ie_uidata *)MemLock( ieb->IF_importOptions );
-
-    if (ieb->IF_formatNumber==FORMAT_SVG)
+    optionsLocked = FALSE;
+    defaultUidata.booleanOptions = SETTINGS_DOTEXT | SETTINGS_DOARCS;
+    uidata = &defaultUidata;
+    if (ieb->IF_importOptions != NullHandle)
     {
-        uidata->booleanOptions = 0;
-        uidata->booleanOptions |= SETTINGS_INPUT_Y_DOWN;    /* SVG is Y-down */
+        uidata = (struct ie_uidata *)MemLock( ieb->IF_importOptions );
+        if (uidata != NULL)
+        {
+            optionsLocked = TRUE;
+        }
+        else
+        {
+            uidata = &defaultUidata;
+        }
     }
 
+    resolvedOptions = uidata->booleanOptions;
+    if (ieb->IF_formatNumber==FORMAT_SVG)
+    {
+        resolvedOptions |= SETTINGS_INPUT_Y_DOWN;    /* SVG is Y-down */
+    }
+
+    uidata->booleanOptions = resolvedOptions;
+
     tempGS = GrCreateGString( ieb->IF_transferVMFile, GST_VMEM, &gsblock );
-    Meta_Start( uidata->booleanOptions, tempGS, NULL, ieb->IF_transferVMFile );     /* initialize drawing system */
+    Meta_Start( resolvedOptions, tempGS, NULL, ieb->IF_transferVMFile );     /* initialize drawing system */
 
     switch( ieb->IF_formatNumber )
     {
         case FORMAT_CGM:
-        ret = ReadCGM( ieb->IF_sourceFile, uidata->booleanOptions, UpdateProgressPct );
+        ret = ReadCGM( ieb->IF_sourceFile, resolvedOptions, UpdateProgressPct );
         break;
         case FORMAT_HPGL:
-        ret = ReadHPGL( ieb->IF_sourceFile, uidata->booleanOptions, UpdateProgressPct );
+        ret = ReadHPGL( ieb->IF_sourceFile, resolvedOptions, UpdateProgressPct );
         break;
         case FORMAT_SVG:
-        ret = ReadSVG( ieb->IF_sourceFile, uidata->booleanOptions, UpdateProgressPct );
+        ret = ReadSVG( ieb->IF_sourceFile, resolvedOptions, UpdateProgressPct );
         break;
         default:
         ret = TE_INVALID_FORMAT;
@@ -147,7 +166,10 @@ dword _export _pascal ImportProcedure(ImportFrame *ieb,VMChain *vmc)
 
     cif = CIF_GRAPHICS_STRING;      /* we have created a gstring */
 
-    MemUnlock( ieb->IF_importOptions );
+    if (optionsLocked != FALSE)
+    {
+        MemUnlock( ieb->IF_importOptions );
+    }
     *vmc = VMCHAIN_MAKE_FROM_VM_BLOCK(gsblock);
                                     /* return head of VMChain for item */
 


### PR DESCRIPTION
## Summary
- handle TransGetImportOptions without a UI handle by supplying the boolean defaults and allocating the block safely
- guard ImportProcedure against a null importOptions handle by using local defaults and passing the resolved flags to Meta_Start and the readers

## Testing
- gmake -C Library/Breadbox/Impex/VCImpex *(fails: no makefile in this directory)*

------
https://chatgpt.com/codex/tasks/task_e_68cda16693388330915cf1dc0fbfe54c