### PR TITLE
Add PNG translator alpha handling options

### DIFF
--- a/Library/Breadbox/Impex/PNG/API/apiManager.asm
+++ b/Library/Breadbox/Impex/PNG/API/apiManager.asm
@@ -11,6 +11,8 @@ include manager.rdef
 global  PNGIMPORT: far
 global  PNGTESTFILE: far
 global  PNGEXPORT: far
+extrn   PNGIMPORTBUILDOPTIONS:far
+extrn   PNGIMPORTINITUI:far
 
 ; build up the right palette from gstring
 ; global  PALGSTRINGCOLELEMENT: far
@@ -161,8 +163,17 @@ TransGetExportUI endp
 ;--------------------------------------------------------------------------------
 
 TransGetImportOptions proc far
-		xor     dx,dx
-		ret
+                push    dx
+                call    PNGIMPORTBUILDOPTIONS
+                mov     dx, ax
+                or      ax, ax
+                jnz     tgio_success
+                xor     dx, dx
+                stc
+                ret
+tgio_success:
+                clc
+                ret
 TransGetImportOptions endp
 
 ;--------------------------------------------------------------------------------
@@ -210,7 +221,9 @@ TransGetExportOptions endp
 ;--------------------------------------------------------------------------------
 
 TransInitImportUI proc far
-		ret
+                push    dx
+                call    PNGIMPORTINITUI
+                ret
 TransInitImportUI endp
 
 ;--------------------------------------------------------------------------------
@@ -226,7 +239,7 @@ ASM     ends
 InfoResource    segment lmem LMEM_TYPE_GENERAL, mask LMF_IN_RESOURCE
 
 		dw	fmt_1_name,fmt_1_mask
-		D_OPTR	0
+		D_OPTR	PngImportGroup
 		D_OPTR  PngExportGroup
 		dw	0C000h          ; 8000h = only support import, 0C000h = import and export
 		dw	0

--- a/Library/Breadbox/Impex/PNG/Xlat/imppng.goc
+++ b/Library/Breadbox/Impex/PNG/Xlat/imppng.goc
@@ -13,38 +13,208 @@
 
 @include <stdapp.goh>
 @include <impex.goh>
+@include <Objects/colorC.goh>
+@include <Objects/gItemGC.goh>
+@include <Objects/gValueC.goh>
 #include <pnglib.h>
+#include <heap.h>
+#include <graphics.h>
+#include <color.h>
 
-dword _pascal PngImport(ImportFrame *frame, VMChain *chain)
+@extern chunk PngAlphaMethodGroup;
+@extern chunk PngAlphaBlendColor;
+@extern chunk PngAlphaThresholdValue;
+
+static void
+PngImportInitAlphaDefaults(pngAlphaTransformData *patd)
+{
+    patd->method = PNG_AT_BLEND;
+    patd->alphaThreshold = 192;
+    patd->blendColor.RGB_red = 255;
+    patd->blendColor.RGB_green = 255;
+    patd->blendColor.RGB_blue = 255;
+}
+
+static void
+PngImportReadAlphaFromUI(MemHandle optionsUI, pngAlphaTransformData *patd)
+{
+    optr methodGroup;
+    optr colorSelector;
+    optr thresholdValue;
+    ColorAndFlagReturn cafr;
+    RGBColorAsDWord mappedColor;
+    word selection;
+    word threshold;
+
+    if (optionsUI == NullHandle)
+    {
+        return;
+    }
+
+    methodGroup = ConstructOptr(optionsUI, PngAlphaMethodGroup);
+    selection = (word) @call methodGroup::MSG_GEN_ITEM_GROUP_GET_SELECTION();
+    patd->method = (pngAlphaTransformMethod) selection;
+
+    colorSelector = ConstructOptr(optionsUI, PngAlphaBlendColor);
+    cafr.CAFR_unused = 0;
+    cafr.CAFR_indeterminate = FALSE;
+    cafr.CAFR_color.CQ_redOrIndex = 0;
+    cafr.CAFR_color.CQ_info = 0;
+    cafr.CAFR_color.CQ_green = 0;
+    cafr.CAFR_color.CQ_blue = 0;
+    @call colorSelector::MSG_COLOR_SELECTOR_GET_COLOR(&cafr);
+
+    if (cafr.CAFR_color.CQ_info == CF_INDEX)
+    {
+        mappedColor = GrMapColorIndex((GStateHandle)0, cafr.CAFR_color.CQ_redOrIndex);
+        patd->blendColor.RGB_red = (byte) RGB_RED(mappedColor);
+        patd->blendColor.RGB_green = (byte) RGB_GREEN(mappedColor);
+        patd->blendColor.RGB_blue = (byte) RGB_BLUE(mappedColor);
+    }
+    else if (cafr.CAFR_color.CQ_info == CF_RGB)
+    {
+        patd->blendColor.RGB_red = cafr.CAFR_color.CQ_redOrIndex;
+        patd->blendColor.RGB_green = cafr.CAFR_color.CQ_green;
+        patd->blendColor.RGB_blue = cafr.CAFR_color.CQ_blue;
+    }
+    else if (cafr.CAFR_color.CQ_info == CF_GRAY)
+    {
+        patd->blendColor.RGB_red = cafr.CAFR_color.CQ_redOrIndex;
+        patd->blendColor.RGB_green = cafr.CAFR_color.CQ_redOrIndex;
+        patd->blendColor.RGB_blue = cafr.CAFR_color.CQ_redOrIndex;
+    }
+
+    thresholdValue = ConstructOptr(optionsUI, PngAlphaThresholdValue);
+    threshold = (word) @call thresholdValue::MSG_GEN_VALUE_GET_INTEGER_VALUE();
+    patd->alphaThreshold = (byte) threshold;
+}
+
+static void
+PngImportApplyAlphaToUI(MemHandle optionsUI, const pngAlphaTransformData *patd)
+{
+    optr methodGroup;
+    optr colorSelector;
+    optr thresholdValue;
+    ColorQuad color;
+    word selection;
+
+    if ((optionsUI == NullHandle) || (patd == (const pngAlphaTransformData *)0))
+    {
+        return;
+    }
+
+    methodGroup = ConstructOptr(optionsUI, PngAlphaMethodGroup);
+    selection = (word) patd->method;
+    @call methodGroup::MSG_GEN_ITEM_GROUP_SET_SINGLE_SELECTION(selection, FALSE);
+
+    colorSelector = ConstructOptr(optionsUI, PngAlphaBlendColor);
+    color.CQ_redOrIndex = patd->blendColor.RGB_red;
+    color.CQ_info = CF_RGB;
+    color.CQ_green = patd->blendColor.RGB_green;
+    color.CQ_blue = patd->blendColor.RGB_blue;
+    @call colorSelector::MSG_COLOR_SELECTOR_SET_COLOR(color, FALSE);
+
+    thresholdValue = ConstructOptr(optionsUI, PngAlphaThresholdValue);
+    @call thresholdValue::MSG_GEN_VALUE_SET_INTEGER_VALUE((word) patd->alphaThreshold, FALSE);
+}
+
+static MemHandle
+PngImportCreateOptionsBlock(const pngAlphaTransformData *patd)
+{
+    MemHandle optionsH;
+    pngAlphaTransformData *optionsP;
+
+    optionsH = MemAlloc(sizeof(pngAlphaTransformData), HF_FIXED, HAF_ZERO_INIT);
+    if (optionsH == NullHandle)
+    {
+        return NullHandle;
+    }
+
+    optionsP = (pngAlphaTransformData *) MemLock(optionsH);
+    if (optionsP == (pngAlphaTransformData *)0)
+    {
+        MemFree(optionsH);
+        return NullHandle;
+    }
+
+    *optionsP = *patd;
+    MemUnlock(optionsH);
+
+    return optionsH;
+}
+
+MemHandle _pascal
+PngImportBuildOptions(MemHandle optionsUI)
+{
+    pngAlphaTransformData patd;
+
+    PngImportInitAlphaDefaults(&patd);
+
+    if (optionsUI != NullHandle)
+    {
+        PngImportReadAlphaFromUI(optionsUI, &patd);
+    }
+
+    return PngImportCreateOptionsBlock(&patd);
+}
+
+void _pascal
+PngImportInitUI(MemHandle optionsUI)
+{
+    pngAlphaTransformData patd;
+
+    if (optionsUI == NullHandle)
+    {
+        return;
+    }
+
+    PngImportInitAlphaDefaults(&patd);
+    PngImportApplyAlphaToUI(optionsUI, &patd);
+}
+
+dword _pascal
+PngImport(ImportFrame *frame, VMChain *chain)
 {
     VMBlockHandle bmblock;
-    pngAlphaTransformData pngAlphaTransform = {0};
+    pngAlphaTransformData pngAlphaTransform;
+    pngAlphaTransformData *optionsP;
 
-    pngAlphaTransform.method = PNG_AT_BLEND;
-    pngAlphaTransform.blendColor.RGB_red = 255;
-    pngAlphaTransform.blendColor.RGB_green = 255;
-    pngAlphaTransform.blendColor.RGB_blue = 255;
+    PngImportInitAlphaDefaults(&pngAlphaTransform);
 
     *chain = 0;
+
+    if (frame->IF_importOptions != NullHandle)
+    {
+        optionsP = (pngAlphaTransformData *) MemLock(frame->IF_importOptions);
+        if (optionsP != (pngAlphaTransformData *)0)
+        {
+            pngAlphaTransform = *optionsP;
+            MemUnlock(frame->IF_importOptions);
+        }
+    }
+
     bmblock = pngImportConvertFile(frame->IF_sourceFile, frame->IF_transferVMFile, &pngAlphaTransform);
 
     if (bmblock != NullHandle)
     {
         *chain = VMCHAIN_MAKE_FROM_VM_BLOCK(bmblock);
-        return (TE_NO_ERROR | (((dword)CIF_BITMAP) << 16)); /* CIF_BITMAP must be included if no error */
+        return (TE_NO_ERROR | (((dword)CIF_BITMAP) << 16));
     }
 
     return (TE_INVALID_FORMAT);
 }
 
-word _pascal PngTestFile(FileHandle file)
+word _pascal
+PngTestFile(FileHandle file)
 {
-    Boolean isPNG = FALSE;
+    Boolean isPNG;
 
     isPNG = pngImportCheckHeader(file);
 
-    if(!isPNG) return NO_IDEA_FORMAT;
+    if (!isPNG)
+    {
+        return NO_IDEA_FORMAT;
+    }
 
     return TE_NO_ERROR;
-};
-
+}

--- a/Library/Breadbox/Impex/PNG/manager.ui
+++ b/Library/Breadbox/Impex/PNG/manager.ui
@@ -1,4 +1,5 @@
-#include <generic.uih>
+#include "generic.uih"
+#include "Objects/colorC.uih"
 
 start ExportInterface;
 
@@ -46,3 +47,108 @@ PngExportGroup = GenInteraction {
 }
 
 end ExportInterface;
+
+start ImportInterface;
+
+PngAlphaMethodBlend = GenItem {
+    moniker = 'B', "Blend color";
+    identifier = 1;
+}
+
+PngAlphaMethodMask = GenItem {
+    moniker = 'M', "Alpha to mask";
+    identifier = 0;
+}
+
+PngAlphaMethodGroup = GenItemGroup {
+    moniker = 'M', "Method:";
+    hints = {
+      HINT_ITEM_GROUP_MINIMIZE_SIZE,
+      HINT_ITEM_GROUP_DISPLAY_CURRENT_SELECTION
+    }
+    selection = 1;
+    children = PngAlphaMethodBlend, PngAlphaMethodMask;
+}
+
+PngAlphaBlendExplain = GenText {
+    genAttributes = readOnly;
+    text = "Composite the image over a chosen background color, " \
+           "replacing per-pixel alpha with blended results.";
+    hints = {
+      HINT_FIXED_SIZE {
+        word SST_AVG_CHAR_WIDTHS | 60,
+        word SST_LINES_OF_TEXT | 3,
+        word 0
+      }
+    }
+}
+
+PngAlphaBlendColor = ColorSelector {
+    moniker = 'C', "Blend color";
+    hints = {
+      HINT_EXPAND_WIDTH_TO_FIT_PARENT,
+      ATTR_GEN_CONTROL_REQUIRE_UI {
+        word mask CSF_INDEX or mask CSF_RGB or mask CSF_OTHER
+      },
+      ATTR_GEN_CONTROL_PROHIBIT_UI {
+        word mask CSF_PATTERN or mask CSF_DRAW_MASK
+      }
+    }
+}
+
+PngAlphaBlendBox = GenInteraction {
+    moniker = 'B', "Blend Settings";
+    hints = {
+      HINT_DRAW_IN_BOX,
+      HINT_EXPAND_WIDTH_TO_FIT_PARENT,
+      HINT_ORIENT_CHILDREN_VERTICALLY,
+      HINT_CENTER_CHILDREN_ON_MONIKERS
+    }
+    children = PngAlphaBlendExplain, PngAlphaBlendColor;
+}
+
+PngAlphaMaskExplain = GenText {
+    genAttributes = readOnly;
+    text = "Convert the alpha channel to a 1-bit mask. Pixels with " \
+           "alpha at or above the chosen threshold stay opaque.";
+    hints = {
+      HINT_FIXED_SIZE {
+        word SST_AVG_CHAR_WIDTHS | 60,
+        word SST_LINES_OF_TEXT | 3,
+        word 0
+      }
+    }
+}
+
+PngAlphaThresholdValue = GenValue {
+    moniker = 'T', "Alpha threshold";
+    minimum = 0;
+    maximum = 255;
+    increment = 1;
+    value = 192;
+    displayFormat = integer;
+    hints = {
+      HINT_EXPAND_WIDTH_TO_FIT_PARENT
+    }
+}
+
+PngAlphaMaskBox = GenInteraction {
+    moniker = 'M', "Mask Settings";
+    hints = {
+      HINT_DRAW_IN_BOX,
+      HINT_EXPAND_WIDTH_TO_FIT_PARENT,
+      HINT_ORIENT_CHILDREN_VERTICALLY,
+      HINT_CENTER_CHILDREN_ON_MONIKERS
+    }
+    children = PngAlphaMaskExplain, PngAlphaThresholdValue;
+}
+
+PngImportGroup = GenInteraction {
+    hints = {
+      HINT_ORIENT_CHILDREN_VERTICALLY,
+      HINT_EXPAND_WIDTH_TO_FIT_PARENT
+    }
+    children = PngAlphaMethodGroup, PngAlphaBlendBox, PngAlphaMaskBox;
+}
+
+end ImportInterface;

--- a/Library/Breadbox/Impex/PNG/png.gp
+++ b/Library/Breadbox/Impex/PNG/png.gp
@@ -16,6 +16,7 @@ library extgraph
 library pnglib
 
 resource ExportInterface object
+resource ImportInterface object
 
 export TransGetImportUI
 export TransGetExportUI


### PR DESCRIPTION
## Summary
- add an import dialog for the PNG translator with alpha conversion controls
- capture the selected alpha handling options and initialize the UI to blend-on-white defaults
- apply the user-selected alpha transform when importing PNG images

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ce691ed0ac83309ddb1b9fa2621566