### PR TITLE
Refactor BSNWav driver interactions into assembly module

### DIFF
--- a/CInclude/bsnwav.goh
+++ b/CInclude/bsnwav.goh
@@ -270,7 +270,6 @@ int _pascal _export BSNWaveGetPlayState( BSWavPlayStates *playStates);
 
 extern  Boolean _pascal LibRecEntry(    LibraryCallType type,
 					GeodeHandle     client);
-extern  void    _pascal BSCallDriver (void);            //intern
 extern  Boolean _pascal _export BSNWavLoadDriver(GeodeLoadError *gle,
 					 char           *name);
 

--- a/Library/Audio/BSNWav/ASMTOOLS/asmtoolsManager.asm
+++ b/Library/Audio/BSNWav/ASMTOOLS/asmtoolsManager.asm
@@ -1,0 +1,304 @@
+COMMENT @%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+        BestSound NewWave assembly helpers
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%@
+
+include geos.def
+include driver.def
+include geode.def
+include library.def
+
+include bsnwav.def
+include dirksnd.def
+
+SetGeosConvention
+
+FETCH_STRATEGY macro handle, infoOff, infoSeg
+    local   havePointer, loadStrategy
+    mov     bx, infoOff
+    mov     ax, infoSeg
+    mov     es, ax
+    mov     si, es:[bx]
+    mov     dx, es:[bx+2]
+    or      si, dx
+    jnz     havePointer
+
+    push    ds
+    mov     bx, handle
+    call    GeodeInfoDriver
+    mov     es, infoSeg
+    mov     bx, infoOff
+    mov     es:[bx], si
+    mov     es:[bx+2], ds
+    mov     dx, ds
+    pop     ds
+    jmp     short loadStrategy
+
+havePointer:
+loadStrategy:
+    push    ds
+    mov     ds, dx
+    mov     bx, [si]
+    mov     cx, [si+2]
+    pop     ds
+    mov     si, bx
+    mov     es, cx
+endm
+
+;--------------------------------------------------------------------------
+; BSNWAsmGetMaxProperties
+;--------------------------------------------------------------------------
+public  BSNWAsmGetMaxProperties
+BSNWAsmGetMaxProperties proc far    driverHandle:word,
+                                    driverInfoPtrOff:word,
+                                    driverInfoPtrSeg:word,
+                                    rateOff:word,
+                                    rateSeg:word,
+                                    channelsOff:word,
+                                    channelsSeg:word,
+                                    bitsOff:word,
+                                    bitsSeg:word,
+                                    reverseOff:word,
+                                    reverseSeg:word
+        uses    bx, cx, dx, si, di, es
+        .enter
+        FETCH_STRATEGY driverHandle, driverInfoPtrOff, driverInfoPtrSeg
+
+        mov     di, DRE_BSNWAV_GET_MAX_PROPERTIES
+        call    es:[si]
+
+        mov     bx, reverseOff
+        mov     ax, reverseSeg
+        mov     es, ax
+        mov     es:[bx], al
+
+        mov     bx, rateOff
+        mov     ax, rateSeg
+        mov     es, ax
+        mov     es:[bx], cx
+
+        mov     bx, channelsOff
+        mov     ax, channelsSeg
+        mov     es, ax
+        mov     es:[bx], dl
+
+        mov     bx, bitsOff
+        mov     ax, bitsSeg
+        mov     es, ax
+        mov     es:[bx], dh
+
+        .leave
+        ret
+BSNWAsmGetMaxProperties endp
+
+;--------------------------------------------------------------------------
+; BSNWAsmStopRecOrPlay
+;--------------------------------------------------------------------------
+public  BSNWAsmStopRecOrPlay
+BSNWAsmStopRecOrPlay proc far       driverHandle:word,
+                                    driverInfoPtrOff:word,
+                                    driverInfoPtrSeg:word
+        uses    bx, cx, dx, si, di, es
+        .enter
+        FETCH_STRATEGY driverHandle, driverInfoPtrOff, driverInfoPtrSeg
+
+        mov     di, DRE_STOP_REC_OR_PLAY
+        call    es:[si]
+        mov     ax, cx
+
+        .leave
+        ret
+BSNWAsmStopRecOrPlay endp
+
+;--------------------------------------------------------------------------
+; BSNWAsmSetPause
+;--------------------------------------------------------------------------
+public  BSNWAsmSetPause
+BSNWAsmSetPause proc far            driverHandle:word,
+                                    driverInfoPtrOff:word,
+                                    driverInfoPtrSeg:word,
+                                    mode:word
+        uses    bx, cx, dx, si, di, es
+        .enter
+        FETCH_STRATEGY driverHandle, driverInfoPtrOff, driverInfoPtrSeg
+
+        mov     cx, mode
+        mov     ch, 0
+        mov     di, DRE_BSNWAV_SET_PAUSE
+        call    es:[si]
+        mov     al, ch
+        xor     ah, ah
+
+        .leave
+        ret
+BSNWAsmSetPause endp
+
+;--------------------------------------------------------------------------
+; BSNWAsmQueryDeviceCapability
+;--------------------------------------------------------------------------
+public  BSNWAsmQueryDeviceCapability
+BSNWAsmQueryDeviceCapability proc far       driverHandle:word,
+                                            driverInfoPtrOff:word,
+                                            driverInfoPtrSeg:word
+        uses    bx, cx, dx, si, di, es
+        .enter
+        FETCH_STRATEGY driverHandle, driverInfoPtrOff, driverInfoPtrSeg
+
+        mov     di, DRE_SOUND_QUERY_DEVICE_CAPABILITY
+        call    es:[si]
+        mov     ax, dx
+
+        .leave
+        ret
+BSNWAsmQueryDeviceCapability endp
+
+;--------------------------------------------------------------------------
+; BSNWAsmCheckSampleRate
+;--------------------------------------------------------------------------
+public  BSNWAsmCheckSampleRate
+BSNWAsmCheckSampleRate proc far     driverHandle:word,
+                                    driverInfoPtrOff:word,
+                                    driverInfoPtrSeg:word,
+                                    testValue:word
+        uses    bx, cx, dx, si, di, es
+        .enter
+        FETCH_STRATEGY driverHandle, driverInfoPtrOff, driverInfoPtrSeg
+
+        mov     cx, 0
+        mov     ax, MANUFACTURER_ID_BSW
+        mov     bx, DACSF_MIXER_TEST
+        mov     dx, testValue
+        mov     di, DRE_SOUND_DAC_CHECK_SAMPLE_RATE_AND_FORMAT
+        call    es:[si]
+        mov     ax, dx
+
+        .leave
+        ret
+BSNWAsmCheckSampleRate endp
+
+;--------------------------------------------------------------------------
+; BSNWAsmGetStatus
+;--------------------------------------------------------------------------
+public  BSNWAsmGetStatus
+BSNWAsmGetStatus proc far           driverHandle:word,
+                                    driverInfoPtrOff:word,
+                                    driverInfoPtrSeg:word
+        uses    bx, cx, dx, si, di, es
+        .enter
+        FETCH_STRATEGY driverHandle, driverInfoPtrOff, driverInfoPtrSeg
+
+        mov     di, DRE_BSNWAV_GET_STATUS
+        call    es:[si]
+        mov     ax, cx
+
+        .leave
+        ret
+BSNWAsmGetStatus endp
+
+;--------------------------------------------------------------------------
+; BSNWAsmSecondAlloc
+;--------------------------------------------------------------------------
+public  BSNWAsmSecondAlloc
+BSNWAsmSecondAlloc proc far         driverHandle:word,
+                                    driverInfoPtrOff:word,
+                                    driverInfoPtrSeg:word,
+                                    length:word,
+                                    offsetOff:word,
+                                    offsetSeg:word,
+                                    segmentOff:word,
+                                    segmentSeg:word
+        uses    bx, cx, dx, si, di, es
+        .enter
+        FETCH_STRATEGY driverHandle, driverInfoPtrOff, driverInfoPtrSeg
+
+        mov     cx, length
+        mov     di, DRE_BSNWAV_SECOND_ALLOC
+        call    es:[si]
+
+        mov     si, ax                        ; save segment
+
+        mov     bx, offsetOff
+        mov     ax, offsetSeg
+        mov     es, ax
+        mov     es:[bx], dx
+
+        mov     bx, segmentOff
+        mov     ax, segmentSeg
+        mov     es, ax
+        mov     es:[bx], si
+
+        mov     ax, cx
+
+        .leave
+        ret
+BSNWAsmSecondAlloc endp
+
+;--------------------------------------------------------------------------
+; BSNWAsmStartPlay
+;--------------------------------------------------------------------------
+public  BSNWAsmStartPlay
+BSNWAsmStartPlay proc far           driverHandle:word,
+                                    driverInfoPtrOff:word,
+                                    driverInfoPtrSeg:word
+        uses    bx, cx, dx, si, di, es
+        .enter
+        FETCH_STRATEGY driverHandle, driverInfoPtrOff, driverInfoPtrSeg
+
+        mov     di, DRE_BSNWAV_START_PLAY
+        call    es:[si]
+        mov     ax, cx
+
+        .leave
+        ret
+BSNWAsmStartPlay endp
+
+;--------------------------------------------------------------------------
+; BSNWAsmGetAIState
+;--------------------------------------------------------------------------
+public  BSNWAsmGetAIState
+BSNWAsmGetAIState proc far          driverHandle:word,
+                                    driverInfoPtrOff:word,
+                                    driverInfoPtrSeg:word,
+                                    options:word
+        uses    bx, cx, dx, si, di, es
+        .enter
+        FETCH_STRATEGY driverHandle, driverInfoPtrOff, driverInfoPtrSeg
+
+        mov     cx, options
+        mov     di, DRE_BSNWAV_GET_AI_STATE
+        call    es:[si]
+        mov     ax, cx
+
+        .leave
+        ret
+BSNWAsmGetAIState endp
+
+;--------------------------------------------------------------------------
+; BSNWAsmSetSampling
+;--------------------------------------------------------------------------
+public  BSNWAsmSetSampling
+BSNWAsmSetSampling proc far         driverHandle:word,
+                                    driverInfoPtrOff:word,
+                                    driverInfoPtrSeg:word,
+                                    rate:word,
+                                    bits:word,
+                                    channels:word
+        uses    bx, cx, dx, si, di, es
+        .enter
+        FETCH_STRATEGY driverHandle, driverInfoPtrOff, driverInfoPtrSeg
+
+        mov     bx, rate
+        mov     cx, channels
+        mov     dx, bits
+        mov     ch, 0
+        mov     dh, 0
+        mov     di, DRE_BSNWAV_SET_SAMPLING
+        call    es:[si]
+        mov     ax, cx
+
+        .leave
+        ret
+BSNWAsmSetSampling endp
+
+end

--- a/Library/Audio/BSNWav/Main/bsnwav.goc
+++ b/Library/Audio/BSNWav/Main/bsnwav.goc
@@ -73,6 +73,57 @@ Secondarybuffer:
 
 @include "bsnwav.goh"
 
+/******************** Constants/Macros ************************/
+
+// Watcom C 16 bit compatible macros
+#define FP_SEG(fp) ((unsigned short)((unsigned long)(void far *)(fp) >> 16))
+#define FP_OFF(fp) ((unsigned short)(fp))
+#define MK_FP(seg, ofs) ((void far *)(((unsigned long)(seg) << 16) | (unsigned)(ofs)))
+
+/******************** Assembly helpers ************************/
+
+extern void _pascal BSNWAsmGetMaxProperties(GeodeHandle driverHandle,
+                                            word driverInfoPtrOff,
+                                            word driverInfoPtrSeg,
+                                            word rateOff,
+                                            word rateSeg,
+                                            word channelsOff,
+                                            word channelsSeg,
+                                            word bitsOff,
+                                            word bitsSeg,
+                                            word reverseOff,
+                                            word reverseSeg);
+extern word _pascal BSNWAsmStopRecOrPlay(GeodeHandle driverHandle,
+                                         word driverInfoPtrOff,
+                                         word driverInfoPtrSeg);
+extern byte _pascal BSNWAsmSetPause(GeodeHandle driverHandle,
+                                    word driverInfoPtrOff,
+                                    word driverInfoPtrSeg,
+                                    byte mode);
+extern word _pascal BSNWAsmQueryDeviceCapability(GeodeHandle driverHandle,
+                                                 word driverInfoPtrOff,
+                                                 word driverInfoPtrSeg);
+extern word _pascal BSNWAsmCheckSampleRate(GeodeHandle driverHandle,
+                                           word driverInfoPtrOff,
+                                           word driverInfoPtrSeg,
+                                           word testValue);
+extern word _pascal BSNWAsmGetStatus(GeodeHandle driverHandle,
+                                     word driverInfoPtrOff,
+                                     word driverInfoPtrSeg);
+extern word _pascal BSNWAsmStartPlay(GeodeHandle driverHandle,
+                                     word driverInfoPtrOff,
+                                     word driverInfoPtrSeg);
+extern word _pascal BSNWAsmGetAIState(GeodeHandle driverHandle,
+                                      word driverInfoPtrOff,
+                                      word driverInfoPtrSeg,
+                                      word options);
+extern word _pascal BSNWAsmSetSampling(GeodeHandle driverHandle,
+                                       word driverInfoPtrOff,
+                                       word driverInfoPtrSeg,
+                                       word rate,
+                                       word bits,
+                                       word channels);
+
 /******************** Const / Makros ************************/
 
 
@@ -196,36 +247,35 @@ int	_pascal	BSNWPlay(BSWavFormChunk *bfc,word playFlags,optr parent);
 
 Boolean	_pascal	_export BSNWavGetMaxProperties(word *maxRate, byte *maxChannels, byte *maxBits)
 {
-        byte	reverseByte;
+        byte    reverseByte;
 	word	rate = 22050;
-        byte	channels = 1;
-        byte	bits = 8;
+        byte    channels = 1;
+        byte    bits = 8;
+
+        reverseByte = 0;
 
         // Is driver New-Wave compatible ?
         if (compatFlag)
         {
-    	    __asm {
-                push di;
-                mov  di,DRE_BSNWAV_GET_MAX_PROPERTIES;	/* get value */
-    	    }
-
-    	    BSCallDriver();
-
-            __asm {
-                pop  di;
-                mov  rate,cx;
-                mov	 channels,dl;
-                mov	 bits,dh;
-                mov	 reverseByte,al;
-            }
-    	};
+                BSNWAsmGetMaxProperties(sampleDriver,
+                                        FP_OFF(&driverInfo),
+                                        FP_SEG(&driverInfo),
+                                        FP_OFF(&rate),
+                                        FP_SEG(&rate),
+                                        FP_OFF(&channels),
+                                        FP_SEG(&channels),
+                                        FP_OFF(&bits),
+                                        FP_SEG(&bits),
+                                        FP_OFF(&reverseByte),
+                                        FP_SEG(&reverseByte));
+        };
 
         // retVal
         *maxRate = rate;
 	*maxChannels = channels;
         *maxBits = bits;
 
-	return (reverseByte > 0);
+        return (reverseByte > 0);
 }
 
 /*************************************
@@ -241,41 +291,28 @@ Boolean	_pascal	_export BSNWavGetMaxProperties(word *maxRate, byte *maxChannels,
 
 Boolean	  _pascal  _export BSNWaveStopRecOrPlay(void *secPtr)
 {
-        Boolean	back;
-        word	back2;
+        Boolean back;
+        word    back2;
 
-    	// Clear Secondarybuffer
+        back2 = 0;
+
+        // Clear Secondarybuffer
         if (secPtr)
-	{
-    	    BSNWFillSilence(secPtr,secBufLen);
+        {
+                BSNWFillSilence(secPtr,secBufLen);
         };
 
-    	if ( (simFlags == 0) && (compatFlag) )
-    	{
-
-        // Stopping driver
-
-    	  __asm {
-                push ax
-                push dx
-                push di
-                mov  di,DRE_STOP_REC_OR_PLAY
-    	  }
-
-          BSCallDriver();
-
-          __asm {
-                pop  di
-                pop  dx
-                pop  ax
-                mov  back2,cx		// R�ckgabewert
-    	    }
-    	};
+        if ( (simFlags == 0) && (compatFlag) )
+        {
+                back2 = BSNWAsmStopRecOrPlay(sampleDriver,
+                                             FP_OFF(&driverInfo),
+                                             FP_SEG(&driverInfo));
+        };
 
         // Errorflag
-	back = (back2 > 0);
+        back = (back2 > 0);
 
-	return (back);
+        return (back);
 }
 
 /***************************************************************
@@ -501,30 +538,19 @@ void 	_pascal _export BSNWaveStop(void)
 
 byte  _pascal  _export BSNWaveSetPause(byte mode)
 {
-        byte	back;
+        byte    back;
 
-    	if (simFlags == 0 && compatFlag)
-    	{
+        back = 0;
 
-    	  __asm {
-      	    push ax
-      	    push dx
-      	    push di
-            mov	 cl,mode
-      	    mov  di,DRE_BSNWAV_SET_PAUSE
-    	  }
+        if (simFlags == 0 && compatFlag)
+        {
+                back = BSNWAsmSetPause(sampleDriver,
+                                         FP_OFF(&driverInfo),
+                                         FP_SEG(&driverInfo),
+                                         mode);
+        };
 
-          BSCallDriver();
-
-          __asm {
-      	    pop  di
-      	    pop  dx
-      	    pop  ax
-            mov  back,ch		// Rückgabewert
-    	  }
-    	};
-
-	return (back);
+        return (back);
 }
 
 /***************************************************************
@@ -900,9 +926,13 @@ optr _pascal _export BSCNCreateStatusBox(optr parent)
 
 Boolean _pascal _export BSNWaveCheckDriver(word flags, word testValue)
 {
-	word	state;
-        word	numOfDACs;
-        Boolean	respond;
+        word    state;
+        word    numOfDACs;
+        Boolean respond;
+
+        state = 0;
+        numOfDACs = 0;
+        respond = FALSE;
 
         // TestValue = 0 --> BSNW_DRIVER_TEST_VALUE (5)
         if (!testValue)
@@ -911,53 +941,17 @@ Boolean _pascal _export BSNWaveCheckDriver(word flags, word testValue)
         };
 
         // First see is there a driver with DAC-capability
+        numOfDACs = BSNWAsmQueryDeviceCapability(sampleDriver,
+                                                 FP_OFF(&driverInfo),
+                                                 FP_SEG(&driverInfo));
 
-    	__asm {
-      	    push ax
-            push bx
-            push cx
-      	    push dx
-      	    push di
-            mov  di,DRE_SOUND_QUERY_DEVICE_CAPABILITY
-    	}
-
-    	BSCallDriver();
-
-        __asm {
-            mov	 numOfDACs,dx
-      	    pop  di
-      	    pop  dx
-            pop  cx
-            pop  bx
-      	    pop  ax
-    	}
-
-	if (numOfDACs>0)
+        if (numOfDACs > 0)
         {
             // Check the BestSound Capability of the driver
-    	    __asm {
-      	        push ax
-                push bx
-                push cx
-      	        push dx
-      	        push di
-                mov  cx,0			// DAC to check
-                mov  ax,MANUFACTURER_ID_BSW
-                mov  bx,DACSF_MIXER_TEST
-                mov  dx,testValue		// sample rate (in Hz)
-                mov  di,DRE_SOUND_DAC_CHECK_SAMPLE_RATE_AND_FORMAT
-    	    }
-
-    	    BSCallDriver();
-
-            __asm {
-                mov  state,dx
-      	        pop  di
-      	        pop  dx
-                pop  cx
-                pop  bx
-      	        pop  ax
-    	    }
+            state = BSNWAsmCheckSampleRate(sampleDriver,
+                                          FP_OFF(&driverInfo),
+                                          FP_SEG(&driverInfo),
+                                          testValue);
             respond = (state == testValue);
         }
         else
@@ -969,12 +963,12 @@ Boolean _pascal _export BSNWaveCheckDriver(word flags, word testValue)
         };
 
         // Errormessage
-@ifndef	BSNWAV_NO_UI
-	if ((!respond) && (flags & BSNW_SHOW_ERROR_MSG) )
+@ifndef BSNWAV_NO_UI
+        if ((!respond) && (flags & BSNW_SHOW_ERROR_MSG) )
         {
 
-	    (void)UserStandardDialog(	0,              //helpContext,
-            				0,              //customTriggers,
+            (void)UserStandardDialog(   0,              //helpContext,
+                                        0,              //customTriggers,
                                         0,              //arg2,
                                         0,              //arg1,
                                         TEXT_WRONG_DRIVER,
@@ -1015,32 +1009,15 @@ word	_pascal _export BSNWaveGetStatus(void)
 	word	state = 0;
 
         if (compatFlag)
-	{
-            // call driver
-
-    	    __asm {
-      	    	push ax
-                push bx
-                push cx
-      	    	push dx
-      	    	push di
-                mov  di,DRE_BSNWAV_GET_STATUS
-    	    }
-
-    	    BSCallDriver();
-
-            __asm {
-            	mov  state,cx
-      	    	pop  di
-      	    	pop  dx
-                pop  cx
-                pop  bx
-		pop  ax
-    	    }
+        {
+                state = BSNWAsmGetStatus(sampleDriver,
+                                     FP_OFF(&driverInfo),
+                                     FP_SEG(&driverInfo));
         };
 
         return (state);
 }
+
 
 /******************************************************************
 

--- a/Library/Audio/BSNWav/Main/subcode.goc
+++ b/Library/Audio/BSNWav/Main/subcode.goc
@@ -71,6 +71,29 @@ REVISION HISTORY:
 #define FP_OFF(fp) ((unsigned short)(fp))
 #define MK_FP(seg, ofs) ((void far *)(((unsigned long)(seg) << 16) | (unsigned)(ofs)))
 
+/******************** Assembly helpers ************************/
+
+extern word _pascal BSNWAsmSecondAlloc(GeodeHandle driverHandle,
+                                       word driverInfoPtrOff,
+                                       word driverInfoPtrSeg,
+                                       word len,
+                                       word offsetOff,
+                                       word offsetSeg,
+                                       word segmentOff,
+                                       word segmentSeg);
+extern word _pascal BSNWAsmStartPlay(GeodeHandle driverHandle,
+                                     word driverInfoPtrOff,
+                                     word driverInfoPtrSeg);
+extern word _pascal BSNWAsmGetAIState(GeodeHandle driverHandle,
+                                      word driverInfoPtrOff,
+                                      word driverInfoPtrSeg,
+                                      word options);
+extern word _pascal BSNWAsmSetSampling(GeodeHandle driverHandle,
+                                       word driverInfoPtrOff,
+                                       word driverInfoPtrSeg,
+                                       word rate,
+                                       word bits,
+                                       word channels);
 
 /******************** Strings / Globals ***********************/
 
@@ -258,85 +281,6 @@ Boolean	_pascal _export BSNWavLoadDriver(GeodeLoadError *gle, char *name)
         return (demoMode);
 }
 
-/**********************************************************
-
-    BSCallDriver
-
-    C-Subroutine for calling driverfunction
-
- IN	di	Routine number
-
-
- **********************************************************/
-
-void _pascal BSCallDriver ()
-{
-    int segm;
-    int offs;
-    int axsave;
-
-    __asm {
-        push ds
-        push bp
-        push si
-        push ax
-        push bx
-        push cx
-        push dx
-        push di
-    }
-
-    //search entrypoint
-    if (!driverInfo)
-    {
-        driverInfo = GeodeInfoDriver(sampleDriver);
-    }
-
-    segm = FP_SEG(driverInfo) ;
-    offs = FP_OFF(driverInfo) ;
-
-    __asm {
-        pop  di
-        pop  dx
-        pop  cx
-        pop  bx
-        pop  ax
-        mov	 axsave,ax		// "if" will destroy ax
-    };
-
-    // call to entrypoint
-    if ((segm | offs) > 0)
-    {
-        __asm {
-            mov  ax,axsave
-            mov  si, offs
-            mov  ds, segm
-            db   0x3e, 0xff, 0x1c	/* call far ds:[si] */
-        }
-    };
-
-    __asm {
-        pop  si
-        pop  bp
-        pop  ds
-    }
-}
-
-/**********************************************************
-
-    BSNWAllocSecBuffer
-
-        Allocate Secondarybuffer
-
-
- IN:	word		len
-     (glob)simFlags 	> 0	for test purpose only !
-
- OUT:	**ptr	Pointer to Buffer
-        word	real length
-
- **********************************************************/
-
 word _pascal _export BSNWAllocSecBuffer(byte **ptr,word len)
 {
     byte		*ptr2;
@@ -371,32 +315,15 @@ word _pascal _export BSNWAllocSecBuffer(byte **ptr,word len)
     }
     else
     {
-        // call driver
+        len = BSNWAsmSecondAlloc(sampleDriver,
+                                 FP_OFF(&driverInfo),
+                                 FP_SEG(&driverInfo),
+                                 len2,
+                                 FP_OFF(&off),
+                                 FP_SEG(&off),
+                                 FP_OFF(&segm),
+                                 FP_SEG(&segm));
 
-        __asm {
-            push ax
-            push bx
-            push cx
-            push dx
-            push di
-            mov  cx,len2
-            mov  di,DRE_BSNWAV_SECOND_ALLOC
-        }
-
-        BSCallDriver();
-
-        __asm {
-            mov  len,cx
-            mov  off,dx
-            mov  segm,ax
-            pop  di
-            pop  dx
-            pop  cx
-            pop  bx
-            pop  ax
-        }
-
-        // store Pointer
         ptr2 = MK_FP(segm,off);
         *ptr = ptr2;
     };
@@ -989,21 +916,9 @@ Boolean	_pascal	_export BSNWStartPlay(void)
         }
         else
         {
-            __asm {
-                push ax
-                push dx
-                push di
-                mov  di,DRE_BSNWAV_START_PLAY
-            }
-
-            BSCallDriver();
-
-            __asm {
-                pop  di
-                pop  dx
-                pop  ax
-                mov  back2,cx		// retVal
-            }
+                back2 = BSNWAsmStartPlay(sampleDriver,
+                                         FP_OFF(&driverInfo),
+                                         FP_SEG(&driverInfo));
         };
 
         // errorflag
@@ -1033,29 +948,11 @@ word	_pascal _export BSNWaveGetAIState(word options)
 
     if (compatFlag)
     {
-        // call driver
-        __asm {
-            push ax
-            push bx
-            push cx
-            push dx
-            push di
-            mov  di,DRE_BSNWAV_GET_AI_STATE
-            mov  cx,options
-        }
-
-        BSCallDriver();
-
-        __asm {
-            mov  state,cx
-            pop  di
-            pop  dx
-            pop  cx
-            pop  bx
-            pop  ax
-        }
-    };
-
+        state = BSNWAsmGetAIState(sampleDriver,
+                                   FP_OFF(&driverInfo),
+                                   FP_SEG(&driverInfo),
+                                   options);
+    }
     return (state);
 }
 
@@ -1514,26 +1411,12 @@ int	_pascal BSNWSetParams(word rate,word bits,word channels)
 {
         int	back;
 
-        __asm {
-            push ax
-            push dx
-            push di
-            mov  di,DRE_BSNWAV_SET_SAMPLING
-            mov  bx,rate			/* value number */
-            mov  cx,channels
-            mov  ch,0
-            mov  dx,bits
-            mov  dh,0
-        }
-
-        BSCallDriver();
-
-        __asm {
-            pop  di
-            pop  dx
-            pop  ax
-            mov  back,cx		// retVal
-        }
+        back = BSNWAsmSetSampling(sampleDriver,
+                                   FP_OFF(&driverInfo),
+                                   FP_SEG(&driverInfo),
+                                   rate,
+                                   bits,
+                                   channels);
 
     return(back);
 }

--- a/Library/Audio/BSNWav/local.mk
+++ b/Library/Audio/BSNWav/local.mk
@@ -26,6 +26,10 @@
 #include <$(SYSMAKEFILE)>
 
 GOCFLAGS += -L bsnwav
+ASM_TO_OBJS    += ASMTOOLS/asmtoolsManager.asm
+OBJS            += ASMTOOLS/asmtoolsManager.obj
+SRCS            += ASMTOOLS/asmtoolsManager.asm
+
 # CCOMFLAGS += -WDE -w
 # CCOMFLAGS += -O2 -w -w-amp -w-cln -w-pin
 # LINKFLAGS += -N Copyright\20Dirk\20Lausecker\202000


### PR DESCRIPTION
## Summary
- replace the inline driver call assembly in the BSNWav library with calls into a dedicated ASMTOOLS/asmtoolsManager.asm helper module
- update the C sources to rely on the new helpers and remove the old BSCallDriver implementation and declaration
- hook the new assembly module into the build so the wrappers are assembled alongside the library

## Testing
- ninja -C Installed/Library/Audio/BSNWav *(fails: missing build.ninja)*

------
https://chatgpt.com/codex/tasks/task_e_68d454154a0883308f130701dac05ed3