### PR TITLE
Replace SysNotify with file-based logging for QOA audio

### DIFF
--- a/Appl/Audio/Bsqp/Main/subcode.goc
+++ b/Appl/Audio/Bsqp/Main/subcode.goc
@@ -47,6 +47,39 @@ DESCRIPTION:
 #include <ec.h>
 #include <geode.h>
 
+static const char gBQLogFileName[] = "qoa.log";
+
+static void BQ_LogMessage(const char *message)
+{
+    FileHandle      logFileH;
+    FileCreateFlags createFlags;
+    word            messageLen;
+    char            newlineStr[2];
+    word            newlineLen;
+
+    createFlags = (FILE_CREATE_NO_TRUNCATE | FCF_NATIVE | FILE_ACCESS_RW | FILE_DENY_NONE);
+    logFileH = FileCreate(gBQLogFileName, createFlags, FA_ARCHIVE);
+    if (!logFileH)
+    {
+        return;
+    }
+
+    FilePos(logFileH, 0, FILE_POS_END);
+
+    messageLen = (word)strlen(message);
+    if (messageLen > 0)
+    {
+        FileWrite(logFileH, (void*)message, messageLen, FALSE);
+    }
+
+    newlineStr[0] = '\r';
+    newlineStr[1] = '\n';
+    newlineLen = 2;
+    FileWrite(logFileH, (void*)newlineStr, newlineLen, FALSE);
+
+    FileClose(logFileH, TRUE);
+}
+
 
 /**********************************************************************/
 
@@ -692,7 +725,7 @@ void    _pascal BQ_StartPlay(void)
                                  GeodeGetProcessHandle()))
                 {
                     // Error
-                    SysNotify(SNF_CONTINUE,"Playthread","could not be created !");
+                    BQ_LogMessage("Playthread: could not be created");
                     (void) FileClose(fh, TRUE);
                     playFlag = 0;
                 }
@@ -742,7 +775,7 @@ word    BQ_PlayThread(word fileWord)
                 {
                     char dbg[40];
                     sprintf(dbg, "QOAPlayFile ret=%d", playState);
-                    SysNotify(SNF_CONTINUE, dbg, 0);
+                    BQ_LogMessage(dbg);
                 }
             }
             else
@@ -893,7 +926,7 @@ Boolean _pascal BQ_CheckForPlay(void)
                 {
                     char dbg[96];
                     sprintf(dbg, "QOA meta ch=%u rate=%lu frames=%lu", bqQoaInfo.channels, bqQoaInfo.sampleRate, bqQoaInfo.totalFrames);
-                    SysNotify(SNF_CONTINUE, dbg, 0);
+                    BQ_LogMessage(dbg);
                 }
                 retVal = RedrawSettings(0);
             }

--- a/Library/Audio/BSNWav/Main/bsnwav.goc
+++ b/Library/Audio/BSNWav/Main/bsnwav.goc
@@ -51,6 +51,7 @@ Secondarybuffer:
 @include <stdapp.goh>
 
 #include <Ansi/string.h>
+#include <Ansi/stdio.h>
 
 #include <gstring.h>
 #include <library.h>
@@ -64,6 +65,39 @@ Secondarybuffer:
 #include <riff.h>
 
 @include "bsnwav.goh"
+
+static const char gBSNWavLogFileName[] = "qoa.log";
+
+static void BSNWav_LogMessage(const char *message)
+{
+    FileHandle      logFileH;
+    FileCreateFlags createFlags;
+    word            messageLen;
+    char            newlineStr[2];
+    word            newlineLen;
+
+    createFlags = (FILE_CREATE_NO_TRUNCATE | FCF_NATIVE | FILE_ACCESS_RW | FILE_DENY_NONE);
+    logFileH = FileCreate(gBSNWavLogFileName, createFlags, FA_ARCHIVE);
+    if (!logFileH)
+    {
+        return;
+    }
+
+    FilePos(logFileH, 0, FILE_POS_END);
+
+    messageLen = (word)strlen(message);
+    if (messageLen > 0)
+    {
+        FileWrite(logFileH, (void*)message, messageLen, FALSE);
+    }
+
+    newlineStr[0] = '\r';
+    newlineStr[1] = '\n';
+    newlineLen = 2;
+    FileWrite(logFileH, (void*)newlineStr, newlineLen, FALSE);
+
+    FileClose(logFileH, TRUE);
+}
 
 /******************** Constants/Macros ************************/
 
@@ -660,13 +694,12 @@ dword _pascal BSNWaveCalcPlaytimeText(  char    *textBuffer,
 
 void BSNWaveDialogUnknownFormat(word formatID)
 {
+    char logBuf[64];
 
-@ifdef  BSNWAV_NO_UI
-//  sprintf(playStatusText,TEXT_UNKNOWN_WAV_FORMAT_2,formatID);
-//  (void)SysNotify(SNF_CONTINUE,playStatusText,0);
-//  sorry: no UI, no sprintf
-    (void)SysNotify(SNF_CONTINUE,TEXT_UNKNOWN_WAV_FORMAT_2_NO_UI,0);
-@else
+    sprintf(logBuf, TEXT_UNKNOWN_WAV_FORMAT_2, formatID);
+    BSNWav_LogMessage(logBuf);
+
+@ifndef BSNWAV_NO_UI
     sprintf(playStatusText,"%04X",formatID);
     (void)UserStandardDialog(0,              //helpContext,
                              0,              //customTriggers,

--- a/Library/Audio/BSNWav/Main/subcode.goc
+++ b/Library/Audio/BSNWav/Main/subcode.goc
@@ -37,8 +37,9 @@ REVISION HISTORY:
 
 @ifndef BSNWAV_NO_UI
 #include <Ansi/stdio.h>
-#include <Ansi/string.h>
 @endif
+
+#include <Ansi/string.h>
 
 #include <sound.h>
 #include <library.h>
@@ -55,6 +56,39 @@ REVISION HISTORY:
 
 @include "bsnwav.goh"
 @include "Main/subcode.goh"
+
+static const char gBSNWavSubLogFileName[] = "qoa.log";
+
+static void BSNWavSub_LogMessage(const char *message)
+{
+    FileHandle      logFileH;
+    FileCreateFlags createFlags;
+    word            messageLen;
+    char            newlineStr[2];
+    word            newlineLen;
+
+    createFlags = (FILE_CREATE_NO_TRUNCATE | FCF_NATIVE | FILE_ACCESS_RW | FILE_DENY_NONE);
+    logFileH = FileCreate(gBSNWavSubLogFileName, createFlags, FA_ARCHIVE);
+    if (!logFileH)
+    {
+        return;
+    }
+
+    FilePos(logFileH, 0, FILE_POS_END);
+
+    messageLen = (word)strlen(message);
+    if (messageLen > 0)
+    {
+        FileWrite(logFileH, (void*)message, messageLen, FALSE);
+    }
+
+    newlineStr[0] = '\r';
+    newlineStr[1] = '\n';
+    newlineLen = 2;
+    FileWrite(logFileH, (void*)newlineStr, newlineLen, FALSE);
+
+    FileClose(logFileH, TRUE);
+}
 
 /******************** Constants/Makros ************************/
 
@@ -103,7 +137,7 @@ void BSNWDebugNotifyWord(const char *label, word value)
     *ptr++ = hex[value & 0xF];
     *ptr   = '\0';
 
-    SysNotify(SNF_CONTINUE, buf, 0);
+    BSNWavSub_LogMessage(buf);
 }
 
 /******************** Strings / Globals ***********************/

--- a/Library/Audio/QOA/qoa_decode.goc
+++ b/Library/Audio/QOA/qoa_decode.goc
@@ -13,8 +13,42 @@
 #include <system.h>
 
 #include <Ansi/string.h>
+#include <Ansi/stdio.h>
 #include <file.h>
 #include <heap.h>
+
+static const char gQOADecodeLogFileName[] = "qoa.log";
+
+static void QOA_LogMessage(const char *message)
+{
+    FileHandle      logFileH;
+    FileCreateFlags createFlags;
+    word            messageLen;
+    char            newlineStr[2];
+    word            newlineLen;
+
+    createFlags = (FILE_CREATE_NO_TRUNCATE | FCF_NATIVE | FILE_ACCESS_RW | FILE_DENY_NONE);
+    logFileH = FileCreate(gQOADecodeLogFileName, createFlags, FA_ARCHIVE);
+    if (!logFileH)
+    {
+        return;
+    }
+
+    FilePos(logFileH, 0, FILE_POS_END);
+
+    messageLen = (word)strlen(message);
+    if (messageLen > 0)
+    {
+        FileWrite(logFileH, (void*)message, messageLen, FALSE);
+    }
+
+    newlineStr[0] = '\r';
+    newlineStr[1] = '\n';
+    newlineLen = 2;
+    FileWrite(logFileH, (void*)newlineStr, newlineLen, FALSE);
+
+    FileClose(logFileH, TRUE);
+}
 
 /* ---------- QOA on-wire constants ---------- */
 #define QOA_MAGIC               0x716f6166UL /* 'qoaf' big-endian */
@@ -269,21 +303,21 @@ static int  QOA_LoadNextFrame(QOAHandle *q)
 
     if ((word)channels != q->info.channels || samplerate != q->info.sampleRate)
     {
-        SysNotify(SNF_CONTINUE, "QOA frame mismatch", 0);
+        QOA_LogMessage("QOA frame mismatch");
         q->eofReached = TRUE;
         return 0;
     }
 
     if (fsamples == 0 || fsamples > (QOA_SLICES_PER_FRAME * QOA_SLICE_LEN))
     {
-        SysNotify(SNF_CONTINUE, "QOA fsamples invalid", 0);
+        QOA_LogMessage("QOA fsamples invalid");
         q->eofReached = TRUE;
         return 0;
     }
 
     if (fsize < (word)(8 + QOA_LMS_LEN * 4 * (word)channels))
     {
-        SysNotify(SNF_CONTINUE, "QOA fsize too small", 0);
+        QOA_LogMessage("QOA fsize too small");
         q->eofReached = TRUE;
         return 0;
     }
@@ -295,7 +329,7 @@ static int  QOA_LoadNextFrame(QOAHandle *q)
 
     if (dataBytes != expectedBytes)
     {
-        SysNotify(SNF_CONTINUE, "QOA data len mismatch", 0);
+        QOA_LogMessage("QOA data len mismatch");
         q->eofReached = TRUE;
         return 0;
     }
@@ -351,14 +385,14 @@ static int  QOA_LoadNextSliceGroup(QOAHandle *q)
     {
         if (q->frameDataBytesLeft < 8)
         {
-            SysNotify(SNF_CONTINUE, "QOA slice: not enough bytes", 0);
+            QOA_LogMessage("QOA slice: not enough bytes");
             q->eofReached = TRUE;
             return 0;
         }
 
         if (!QOA_Read8(q->fileH, slice8, 8))
         {
-            SysNotify(SNF_CONTINUE, "QOA slice: read failure", 0);
+            QOA_LogMessage("QOA slice: read failure");
             q->eofReached = TRUE;
             return 0;
         }
@@ -370,7 +404,7 @@ static int  QOA_LoadNextSliceGroup(QOAHandle *q)
         q->scalefactor[c] = (byte)QBR_Get(&q->sliceBits[c], 4, &ok);
         if (!ok)
         {
-            SysNotify(SNF_CONTINUE, "QOA slice: scalefactor error", 0);
+            QOA_LogMessage("QOA slice: scalefactor error");
             q->eofReached = TRUE;
             return 0;
         }
@@ -396,7 +430,7 @@ static word QOA_ProduceFromFrame(QOAHandle *q, word maxFrames, signed short *out
         {
             if (!QOA_LoadNextSliceGroup(q))
             {
-                SysNotify(SNF_CONTINUE, "QOA: failed to load slice group", 0);
+                QOA_LogMessage("QOA: failed to load slice group");
                 break;
             }
         }
@@ -422,7 +456,7 @@ static word QOA_ProduceFromFrame(QOAHandle *q, word maxFrames, signed short *out
                 code3 = QBR_Get(&q->sliceBits[ch], 3, &ok);
                 if (!ok)
                 {
-                    SysNotify(SNF_CONTINUE, "QOA bits read error", 0);
+                    QOA_LogMessage("QOA bits read error");
                     q->eofReached = TRUE;
                     return produced;
                 }
@@ -536,7 +570,7 @@ dword _pascal qoaReadS16(QOAHandle *q, dword framesToRead, signed short *dst)
         {
             if (!QOA_LoadNextFrame(q))
             {
-                SysNotify(SNF_CONTINUE, "qoaReadS16: no more frames", 0);
+                QOA_LogMessage("qoaReadS16: no more frames");
                 break;
             }
         }
@@ -546,7 +580,7 @@ dword _pascal qoaReadS16(QOAHandle *q, dword framesToRead, signed short *dst)
         {
             char dbg[60];
             sprintf(dbg, "qoaReadS16: want=%lu got=%u left=%u", framesToRead, got, q->frameSamplesLeft);
-            SysNotify(SNF_CONTINUE, dbg, 0);
+            QOA_LogMessage(dbg);
         }
         if (got == 0)
         {

--- a/Library/Audio/QOA/qoa_play.goc
+++ b/Library/Audio/QOA/qoa_play.goc
@@ -6,8 +6,11 @@
 @include <bsnwav.goh>
 
 #include <Ansi/string.h>
+#include <Ansi/stdio.h>
 #include <library.h>
 #include <system.h>
+#include <file.h>
+#include <heap.h>
 
 
 /* ------------ Internal static playback context ------------ */
@@ -15,6 +18,104 @@
 static QOAHandle *s_qoaHandle = 0;
 static word       s_qoaChannels = 1;
 static dword      s_totalFramesDecoded = 0;
+
+static const char gQOALogFileName[] = "qoa.log";
+
+static void QOA_LogMessage(const char *message)
+{
+    FileHandle      logFileH;
+    FileCreateFlags createFlags;
+    word            messageLen;
+    char            newlineStr[2];
+    word            newlineLen;
+
+    createFlags = (FILE_CREATE_NO_TRUNCATE | FCF_NATIVE | FILE_ACCESS_RW | FILE_DENY_NONE);
+    logFileH = FileCreate(gQOALogFileName, createFlags, FA_ARCHIVE);
+    if (!logFileH)
+    {
+        return;
+    }
+
+    FilePos(logFileH, 0, FILE_POS_END);
+
+    messageLen = (word)strlen(message);
+    if (messageLen > 0)
+    {
+        FileWrite(logFileH, (void*)message, messageLen, FALSE);
+    }
+
+    newlineStr[0] = '\r';
+    newlineStr[1] = '\n';
+    newlineLen = 2;
+    FileWrite(logFileH, (void*)newlineStr, newlineLen, FALSE);
+
+    FileClose(logFileH, TRUE);
+}
+
+static Boolean QOA_VerifyDecoder(QOAHandle *qh, const QOAInfo *info)
+{
+    MemHandle      bufferH;
+    signed short  *bufferP;
+    dword          framesRequested;
+    dword          framesDecoded;
+    word           bufferSize;
+    Boolean        success;
+    char           dbg[80];
+
+    framesRequested = 64;
+    success = FALSE;
+
+    if (!info || info->channels == 0)
+    {
+        QOA_LogMessage("QOA verify: invalid decoder info");
+        return FALSE;
+    }
+
+    bufferSize = (word)(framesRequested * (dword)info->channels * sizeof(signed short));
+    if (bufferSize == 0)
+    {
+        QOA_LogMessage("QOA verify: calculated buffer size is zero");
+        return FALSE;
+    }
+
+    bufferH = MemAlloc(bufferSize, HF_SWAPABLE, HAF_ZERO_INIT);
+    if (bufferH == NullHandle)
+    {
+        QOA_LogMessage("QOA verify: MemAlloc failed");
+        return FALSE;
+    }
+
+    bufferP = (signed short*)MemLock(bufferH);
+    if (!bufferP)
+    {
+        MemFree(bufferH);
+        QOA_LogMessage("QOA verify: MemLock failed");
+        return FALSE;
+    }
+
+    framesDecoded = qoaReadS16(qh, framesRequested, bufferP);
+    if (framesDecoded > 0)
+    {
+        sprintf(dbg, "QOA verify: decoded %lu frames", framesDecoded);
+        QOA_LogMessage(dbg);
+        success = TRUE;
+    }
+    else
+    {
+        QOA_LogMessage("QOA verify: decoder produced zero frames");
+    }
+
+    MemUnlock(bufferH);
+    MemFree(bufferH);
+
+    if (!qoaSeek(qh, 0))
+    {
+        QOA_LogMessage("QOA verify: failed to seek to start");
+        success = FALSE;
+    }
+
+    return success;
+}
 
 static void QOA_ResetStaticState(void)
 {
@@ -70,7 +171,7 @@ static word _pascal QOA_BSNW_Callback(void *dstBuf, word wantBytes)
             framesGot = qoaReadS16(s_qoaHandle, framesDesired, writePtr);
             if (framesGot == 0)
             {
-                SysNotify(SNF_CONTINUE, "QOA cb: EOF", 0);
+                QOA_LogMessage("QOA cb: EOF");
                 break;
             }
 
@@ -81,7 +182,7 @@ static word _pascal QOA_BSNW_Callback(void *dstBuf, word wantBytes)
             {
                 char dbg[50];
                 sprintf(dbg, "QOA cb: got=%lu bytes=%lu", framesGot, producedBytes);
-                SysNotify(SNF_CONTINUE, dbg, 0);
+                QOA_LogMessage(dbg);
             }
 
             if (framesGot < framesDesired)
@@ -117,11 +218,20 @@ int _pascal _export QOAPlayFile(FileHandle fh, word playFlags, optr parent)
     qh = qoaOpenGEOS(fh, &info);
     if (!qh)
     {
+        QOA_LogMessage("QOAPlayFile: qoaOpenGEOS failed");
         return BSNW_UNKNOWN_WAVE_FORMAT;
     }
 
     s_qoaHandle   = qh;
     s_qoaChannels = info.channels;
+
+    if (!QOA_VerifyDecoder(qh, &info))
+    {
+        QOA_LogMessage("QOAPlayFile: decoder verification failed");
+        qoaClose(qh);
+        QOA_ResetStaticState();
+        return BSNW_UNKNOWN_WAVE_FORMAT;
+    }
 
     fmt.BWFC_dataFormat    = 1; /* PCM */
     fmt.BWFC_channels      = info.channels;
@@ -142,7 +252,7 @@ int _pascal _export QOAPlayFile(FileHandle fh, word playFlags, optr parent)
     {
         char dbg[40];
         sprintf(dbg, "QOA frames=%lu", s_totalFramesDecoded);
-        SysNotify(SNF_CONTINUE, dbg, 0);
+        QOA_LogMessage(dbg);
     }
 
     QOA_ResetStaticState();


### PR DESCRIPTION
## Summary
- add reusable file-based logging helpers to the QOA decoder/player so callbacks and failure paths write to qoa.log instead of issuing SysNotify alerts
- verify QOA decoding up front by decoding a small sample and logging the result before starting playback
- switch the Bsqp player and BSNWav library to use the same log file for thread creation, metadata, debug output, and unknown format errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e36e848ec08330b611ad0673559e11