### PR TITLE
Optimize MP3 volume scaling fast paths

### DIFF
--- a/Library/Audio/BSNWav/MP3/mp3_decode.goc
+++ b/Library/Audio/BSNWav/MP3/mp3_decode.goc
@@ -60,12 +60,20 @@ MP3_ScalePcmWithWWFixed(sword *samplesP, word sampleCount, WWFixed volume)
     long prod;
     sword s;
 
+    if ((volume.FXwhole == 0) && (volume.FXfrac == 0)) {
+        _fmemset(samplesP, 0, (word)(sampleCount * sizeof(sword)));
+        return;
+    }
     if ((volume.FXwhole == 1) && (volume.FXfrac == 0)) {
         return;
     }
     for (i = 0; i < sampleCount; i++) {
         s = samplesP[i];
-        prod = ((long)s * (long)volume.FXwhole) << 16;
+        if (volume.FXwhole != 0) {
+            prod = ((long)s << 16);
+        } else {
+            prod = 0;
+        }
         prod += ((long)s * (long)volume.FXfrac);
         prod >>= 16;
         if (prod > 32767) prod = 32767;


### PR DESCRIPTION
## Summary
- zero out decoded PCM quickly when WWFixed volume is 0.0
- avoid redundant integer multiply in the sample scaling loop while preserving saturation behavior

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e64b3964048330bda3038b6e095f38