### PR TITLE
Optimize MP3 stereo-to-mono mix shift

### DIFF
--- a/Library/Audio/BSNWav/MP3/mp3_decode.goc
+++ b/Library/Audio/BSNWav/MP3/mp3_decode.goc
@@ -86,9 +86,9 @@ MP3_MixStereoToMonoInPlace(sword *pcmP, word stereoSamples)
     for (i = 0; i < stereoSamples; i++) {
         L = (long)pcmP[2*i + 0];
         R = (long)pcmP[2*i + 1];
-        m = (L + R) / 2;
+        m = (L + R) >> 1;
         if (m > 32767) m = 32767;
-        if (m < -32768) m = -32768;
+        if (m < -32767) m = -32767;
         pcmP[i] = (sword)m;
     }
     return (word)(stereoSamples * 2); /* mono bytes */


### PR DESCRIPTION
## Summary
- replace the stereo-to-mono mix average with an arithmetic right shift to enable cheaper code generation
- clamp the shifted value to ±32767 to preserve audio safety

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e64b4042f0833085fd8846e03e2464