### PR TITLE
Preserve stack frame on RawTcp escape dispatch

### DIFF
--- a/Driver/Stream/RawTcp/rawtcpMain.asm
+++ b/Driver/Stream/RawTcp/rawtcpMain.asm
@@ -177,10 +177,10 @@ REVISION HISTORY:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%@%
 RawTcpStrategy	proc	far
 	uses	es, ds
-	.enter
-
 	tst	di
 	js	handleEscape
+
+	.enter
 
 	segmov	es, ds
 	mov	ds, cs:rawTcpData
@@ -210,7 +210,12 @@ doNotYetOpenCall:
 	jmp	exit
 
 handleEscape:
-	GOTO	RawTcpEscape
+	push	es
+	push	ds
+	call	RawTcpEscape
+	pop	ds
+	pop	es
+	ret
 
 exit:
 	.leave


### PR DESCRIPTION
### Motivation

- Prevent the escape dispatch from bypassing a pending `.leave` in `RawTcpStrategy` which could unbalance the stack frame.
- Mirror the behavior of `NetstreamStrategy` where escape handling does not skip prologue/epilogue pairing. 
- Keep segment registers preserved across the escape call so the driver state (`es`, `ds`) remains intact. 

### Description

- Move the `.enter` prologue to occur after the `tst di`/escape check so the escape path runs without bypassing `.leave`.
- Replace the `GOTO RawTcpEscape` with a `call RawTcpEscape` followed by an immediate `ret` so escape handlers return into the strategy epilogue path correctly. 
- Push and pop `es`/`ds` around the `call RawTcpEscape` to preserve segment registers during escape dispatch. 
- No other control-flow paths were altered and the normal `exit` label still performs `.leave` before `ret`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962635917c88330b0b0c786db4680c7)