### PR TITLE
Enable tcsh-style command-line editor and history searching by default

### DIFF
--- a/Tools/swat/lib.new/toplevel.tcl
+++ b/Tools/swat/lib.new/toplevel.tcl
@@ -979,3 +979,14 @@ See Also:
 }]
 
 var defaultCleChars {aebfrvdtkyu}
+
+#
+# Enable the existing command-line editor by default. Users can still
+# put "tcsh off" or "tcsh cle off" in swat.rc to disable it.
+#
+if {[null $cleChars]} {
+    var cleChars $defaultCleChars
+}
+if {[null $historySearching]} {
+    var historySearching 1
+}


### PR DESCRIPTION
### Motivation
- Ensure the existing tcsh-style command-line editor and history searching are enabled by default so users get command-line editing and history behavior without extra configuration while preserving the ability to disable them via `tcsh off` or `tcsh cle off` in `swat.rc`.

### Description
- Add default initialization that sets `cleChars` to `defaultCleChars` when `cleChars` is null and sets `historySearching` to `1` when `historySearching` is null, with comments explaining the default behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4caf635d548330bc070c1155b02cb7)